### PR TITLE
Add release.yaml to path filter

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.github/workflows/release.yaml'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'


### PR DESCRIPTION
## Problem

The `release.yaml` workflow has a path filter that excludes workflow file changes:

```yaml
paths:
  - 'crates/wasm/**'
  - 'src/**'
  - 'Cargo.toml'
  - 'Cargo.lock'
  # ❌ Missing: .github/workflows/release.yaml
```

This caused PR #40 (hotfix for syntax error) to NOT trigger the workflow, so we couldn't verify the fix worked.

## Fix

Add `.github/workflows/release.yaml` to the path filter so changes to the workflow itself trigger a test run.

```yaml
paths:
  - 'crates/wasm/**'
  - 'src/**'
  - 'Cargo.toml'
  - 'Cargo.lock'
  - '.github/workflows/release.yaml'  # ✅ Added
```

## Impact

- ✅ Workflow changes now trigger the workflow (can test the workflow)
- ✅ Still filtered to only run on relevant file changes
- ✅ Won't run on README or other doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)