### PR TITLE
feat: add rustls-tls and native-tls feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 aes-gcm = "0.10"
 
 # KAS client dependencies (simplified, crypto moved to opentdf-crypto)
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 jsonwebtoken = { version = "9", optional = true }
 
@@ -38,12 +38,14 @@ rand = "0.8"
 members = ["crates/protocol", "crates/crypto", "crates/wasm"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 
 [features]
 default = ["kas"]
 mcp = []
-kas = ["reqwest", "tokio", "jsonwebtoken", "opentdf-crypto/kas"]
+kas = ["dep:reqwest", "dep:tokio", "dep:jsonwebtoken", "opentdf-crypto/kas", "rustls-tls"]
+rustls-tls = ["reqwest?/rustls-tls"]
+native-tls = ["reqwest?/native-tls"]
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
## Summary
- Add `rustls-tls` and `native-tls` feature flags for TLS backend selection
- Default to `rustls-tls` when using the `kas` feature (pure Rust, no OpenSSL dependency)
- Bump version to 0.6.1

## Usage

```toml
# Default (rustls-tls)
opentdf = { version = "0.6", features = ["kas"] }

# Explicit native-tls (for users who need OpenSSL)
opentdf = { version = "0.6", default-features = false, features = ["kas", "native-tls"] }
```

## Test plan
- [x] `cargo build --features kas` - rustls-tls compiles
- [x] `cargo build --no-default-features --features kas,native-tls` - native-tls compiles
- [x] `cargo test` - all tests pass
- [x] `cargo clippy --all-targets --all-features` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)