### PR TITLE
DX: Type conversions Default implementation

### DIFF
--- a/crates/protocol/src/manifest.rs
+++ b/crates/protocol/src/manifest.rs
@@ -35,6 +35,19 @@ pub struct Payload {
     pub tdf_spec_version: Option<String>,
 }
 
+impl Default for Payload {
+    fn default() -> Self {
+        Self {
+            payload_type: "reference".to_string(),
+            url: "0.payload".to_string(),
+            protocol: "zip".to_string(),
+            is_encrypted: true,
+            mime_type: Some("application/octet-stream".to_string()),
+            tdf_spec_version: Some("3.0.0".to_string()),
+        }
+    }
+}
+
 /// Encryption information in TDF manifest
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncryptionInformation {
@@ -102,6 +115,16 @@ pub struct EncryptionMethod {
     pub iv: String,
 }
 
+impl Default for EncryptionMethod {
+    fn default() -> Self {
+        Self {
+            algorithm: "AES-256-GCM".to_string(),
+            is_streamable: true,
+            iv: String::new(),
+        }
+    }
+}
+
 /// Integrity information including segments and root signature
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IntegrityInformation {
@@ -116,11 +139,32 @@ pub struct IntegrityInformation {
     pub encrypted_segment_size_default: u64,
 }
 
+impl Default for IntegrityInformation {
+    fn default() -> Self {
+        Self {
+            root_signature: RootSignature::default(),
+            segment_hash_alg: "GMAC".to_string(),
+            segments: Vec::new(),
+            segment_size_default: 1024 * 1024,                // 1MB
+            encrypted_segment_size_default: 1024 * 1024 + 28, // +IV+tag
+        }
+    }
+}
+
 /// Root signature for integrity verification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RootSignature {
     pub alg: String,
     pub sig: String,
+}
+
+impl Default for RootSignature {
+    fn default() -> Self {
+        Self {
+            alg: "HS256".to_string(),
+            sig: String::new(),
+        }
+    }
 }
 
 /// Segment information

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -218,6 +218,121 @@ impl TdfJsonRpc {
     }
 }
 
+// ============================================================================
+// Type Conversions between manifest and inline types
+// ============================================================================
+
+impl From<&TdfManifest> for TdfManifestInline {
+    /// Convert a standard TDF manifest to inline format.
+    ///
+    /// Note: The payload value will be empty and must be set separately
+    /// since the original payload is a file reference, not inline data.
+    fn from(manifest: &TdfManifest) -> Self {
+        Self {
+            payload: InlinePayload {
+                payload_type: "inline".to_string(),
+                mime_type: manifest
+                    .payload
+                    .mime_type
+                    .clone()
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+                protocol: "base64".to_string(),
+                value: String::new(), // Must be set separately
+                is_encrypted: manifest.payload.is_encrypted,
+            },
+            encryption_information: manifest.encryption_information.clone(),
+            schema_version: manifest.schema_version.clone(),
+        }
+    }
+}
+
+impl From<TdfManifest> for TdfManifestInline {
+    /// Convert a standard TDF manifest to inline format (consuming version).
+    ///
+    /// Note: The payload value will be empty and must be set separately
+    /// since the original payload is a file reference, not inline data.
+    fn from(manifest: TdfManifest) -> Self {
+        Self {
+            payload: InlinePayload {
+                payload_type: "inline".to_string(),
+                mime_type: manifest
+                    .payload
+                    .mime_type
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+                protocol: "base64".to_string(),
+                value: String::new(), // Must be set separately
+                is_encrypted: manifest.payload.is_encrypted,
+            },
+            encryption_information: manifest.encryption_information,
+            schema_version: manifest.schema_version,
+        }
+    }
+}
+
+impl From<&TdfManifestInline> for TdfManifest {
+    /// Convert an inline manifest back to standard TDF manifest format.
+    fn from(inline: &TdfManifestInline) -> Self {
+        Self {
+            payload: Payload {
+                payload_type: "reference".to_string(),
+                url: "inline".to_string(),
+                protocol: "base64".to_string(),
+                is_encrypted: inline.payload.is_encrypted,
+                mime_type: Some(inline.payload.mime_type.clone()),
+                tdf_spec_version: None,
+            },
+            encryption_information: inline.encryption_information.clone(),
+            schema_version: inline.schema_version.clone(),
+        }
+    }
+}
+
+impl From<TdfManifestInline> for TdfManifest {
+    /// Convert an inline manifest back to standard TDF manifest format (consuming version).
+    fn from(inline: TdfManifestInline) -> Self {
+        Self {
+            payload: Payload {
+                payload_type: "reference".to_string(),
+                url: "inline".to_string(),
+                protocol: "base64".to_string(),
+                is_encrypted: inline.payload.is_encrypted,
+                mime_type: Some(inline.payload.mime_type),
+                tdf_spec_version: None,
+            },
+            encryption_information: inline.encryption_information,
+            schema_version: inline.schema_version,
+        }
+    }
+}
+
+impl From<&InlinePayload> for Payload {
+    /// Convert an inline payload to a standard payload reference.
+    fn from(inline: &InlinePayload) -> Self {
+        Self {
+            payload_type: "reference".to_string(),
+            url: "inline".to_string(),
+            protocol: "base64".to_string(),
+            is_encrypted: inline.is_encrypted,
+            mime_type: Some(inline.mime_type.clone()),
+            tdf_spec_version: None,
+        }
+    }
+}
+
+impl From<InlinePayload> for Payload {
+    /// Convert an inline payload to a standard payload reference (consuming version).
+    fn from(inline: InlinePayload) -> Self {
+        Self {
+            payload_type: "reference".to_string(),
+            url: "inline".to_string(),
+            protocol: "base64".to_string(),
+            is_encrypted: inline.is_encrypted,
+            mime_type: Some(inline.mime_type),
+            tdf_spec_version: None,
+        }
+    }
+}
+
 impl TdfJsonRpcBuilder {
     /// Set the KAS (Key Access Service) URL
     #[must_use]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -47,7 +47,16 @@ pub use opentdf_crypto::{
 // Users don't need to explicitly import these anymore
 pub use crate::manifest::{IntegrityInformationExt, KeyAccessExt, TdfManifestExt};
 
-// KAS types (when feature enabled)
+// JSON-RPC types for inline TDF workflows
+pub use crate::jsonrpc::{InlinePayload, TdfJsonRpc, TdfJsonRpcBuilder, TdfManifestInline};
+
+// KAS protocol types for direct KAS integration
+pub use opentdf_protocol::{
+    KasPolicyBinding, KeyAccessObject, KeyAccessObjectWrapper, PolicyRequest, SignedRewrapRequest,
+    UnsignedRewrapRequest,
+};
+
+// KAS client types (when feature enabled)
 #[cfg(feature = "kas-client")]
 pub use crate::kas::KasClient;
 


### PR DESCRIPTION
## Summary

- Add `Default` implementations for `RootSignature`, `IntegrityInformation`, `EncryptionMethod`, and `Payload` to eliminate manual construction boilerplate
- Add `From`/`Into` conversions between `PolicyBinding` and `KasPolicyBinding`
- Add `From`/`Into` conversions between `KeyAccess` and `KeyAccessObject`
- Add `From`/`Into` conversions for `TdfManifest`/`TdfManifestInline` and `InlinePayload`/`Payload`
- Expand prelude with JSON-RPC and KAS protocol types for easier imports

## Test plan

- [x] All existing tests pass (74 tests)
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)