### PR TITLE
feat: add EC key wrapping support for TDF3 manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 
 [dependencies]
 # New modular crates
-opentdf-protocol = { path = "crates/protocol", version = "0.9.0" }
-opentdf-crypto = { path = "crates/crypto", version = "0.9.0", default-features = false }
+opentdf-protocol = { path = "crates/protocol", version = "0.10.0" }
+opentdf-crypto = { path = "crates/crypto", version = "0.10.0", default-features = false }
 
 # Core dependencies (using workspace versions)
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
@@ -49,7 +49,7 @@ rand = "0.8"
 members = ["crates/protocol", "crates/crypto", "crates/wasm"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 
 [workspace.dependencies]
 # Core serialization

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -36,7 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 # Protocol types (for NanoTDF)
-opentdf-protocol = { path = "../protocol", version = "0.9.0" }
+opentdf-protocol = { path = "../protocol", version = "0.10.0" }
 
 # KAS feature dependencies (EC, HKDF)
 p256 = { workspace = true, optional = true }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -18,10 +18,10 @@ pub mod nanotdf;
 pub use kas::{
     KasError, KasPolicyBinding, KeyAccessObject, KeyAccessObjectWrapper, KeyAccessRewrapResult,
     Policy as KasPolicy, PolicyRequest, PolicyRewrapResult, RewrapResponse, SignedRewrapRequest,
-    UnsignedRewrapRequest,
+    UnsignedRewrapRequest, algorithm,
 };
 
 pub use manifest::{
     EncryptionInformation, EncryptionMethod, IntegrityInformation, KeyAccess, Payload,
-    PolicyBinding, RootSignature, Segment, TdfManifest,
+    PolicyBinding, RootSignature, Segment, TdfManifest, key_access_type,
 };

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -26,8 +26,8 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-opentdf = { path = "../..", version = "0.9.0", default-features = false }
-opentdf-protocol = { path = "../protocol", version = "0.9.0" }
+opentdf = { path = "../..", version = "0.10.0", default-features = false }
+opentdf-protocol = { path = "../protocol", version = "0.10.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde.workspace = true

--- a/crates/wasm/src/kas.rs
+++ b/crates/wasm/src/kas.rs
@@ -184,6 +184,7 @@ pub fn build_rewrap_request(
                 encrypted_metadata: kao.encrypted_metadata.clone(),
                 kid: kao.kid.clone(),
                 header: None, // Only used for NanoTDF rewrap requests
+                ephemeral_public_key: kao.ephemeral_public_key.clone(),
             },
         })
         .collect();

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -394,6 +394,7 @@ impl TdfJsonRpcBuilder {
             },
             encrypted_metadata: None,
             schema_version: Some("1.0".to_string()),
+            ephemeral_public_key: None, // RSA wrapping, no ephemeral key needed
         };
 
         // Calculate encrypted size from base64 string length (more efficient than decoding)
@@ -557,6 +558,7 @@ mod tests {
             },
             encrypted_metadata: None,
             schema_version: Some("1.0".to_string()),
+            ephemeral_public_key: None,
         };
 
         // Create integrity information

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -481,6 +481,7 @@ impl KasClient {
                         encrypted_metadata: kao.encrypted_metadata.clone(),
                         kid: kao.kid.clone(),
                         header: None, // Not used for standard TDF
+                        ephemeral_public_key: kao.ephemeral_public_key.clone(),
                     },
                 })
             })
@@ -531,7 +532,8 @@ impl KasClient {
                 },
                 encrypted_metadata: None,
                 kid: None,
-                header: Some(header_b64), // NanoTDF header bytes (base64)
+                header: Some(header_b64),   // NanoTDF header bytes (base64)
+                ephemeral_public_key: None, // Not used for NanoTDF rewrap
             },
         };
 


### PR DESCRIPTION
## Summary

- Add `key_access_type` module with `WRAPPED`, `EC_WRAPPED`, `REMOTE`, `REMOTE_WRAPPED` constants
- Add `ephemeral_public_key` field to `KeyAccess` struct
- Add `new_ec_wrapped()` constructor and `is_ec_wrapped()`/`is_rsa_wrapped()` helpers
- Add `algorithm` module with `RSA_2048`, `EC_P256`, `EC_P384`, `EC_P521` constants
- Add `detect_algorithm()` method to `KeyAccessObject`
- Update type conversions to include `ephemeral_public_key`
- Bump version to 0.10.0

This enables full EC support for TDF3 manifest format, complementing the existing NanoTDF EC support.

## Test plan

- [x] All unit tests pass (56 tests)
- [x] All integration tests pass
- [x] Build succeeds with cargo build
- [ ] Cross-SDK compatibility testing with OpenTDFKit

🤖 Generated with [Claude Code](https://claude.ai/code)