### PR TITLE
fix: Split HKDF salts for DEK and session key derivation

### DIFF
--- a/crates/kas/src/rewrap.rs
+++ b/crates/kas/src/rewrap.rs
@@ -15,23 +15,30 @@ use sha2::Sha256;
 ///
 /// Derives the actual DEK from ECDH shared secret, then wraps it for transport.
 ///
+/// The DEK salt and session salt are separate because they serve different purposes:
+/// - `dek_salt`: Version-dependent salt for deriving the DEK (matches NanoTDF header version)
+/// - `session_salt`: Always v1.2 salt (SHA256("L1L")) for the session key, since the session
+///   key exchange is a transport-layer concern independent of the NanoTDF format version.
+///   The Go reference KAS and all SDK clients hardcode v1.2 for session key derivation.
+///
 /// # Steps
-/// 1. Derive DEK from dek_shared_secret using HKDF with salt
-/// 2. Derive wrapping key from session_shared_secret using HKDF with salt
+/// 1. Derive DEK from dek_shared_secret using HKDF with dek_salt
+/// 2. Derive wrapping key from session_shared_secret using HKDF with session_salt
 /// 3. Encrypt derived DEK with AES-256-GCM using wrapping key
 pub fn rewrap_dek(
     dek_shared_secret: &[u8],
     session_shared_secret: &[u8],
-    salt: &[u8],
+    dek_salt: &[u8],
+    session_salt: &[u8],
     info: &[u8],
 ) -> Result<(Vec<u8>, Vec<u8>), KasServerError> {
     // Derive the actual DEK from the TDF ECDH shared secret
-    let dek_hkdf = Hkdf::<Sha256>::new(Some(salt), dek_shared_secret);
+    let dek_hkdf = Hkdf::<Sha256>::new(Some(dek_salt), dek_shared_secret);
     let mut dek = [0u8; 32];
     dek_hkdf.expand(info, &mut dek)?;
 
-    // Derive the wrapping key from the session shared secret
-    let session_hkdf = Hkdf::<Sha256>::new(Some(salt), session_shared_secret);
+    // Derive the wrapping key from the session shared secret (always v1.2 salt)
+    let session_hkdf = Hkdf::<Sha256>::new(Some(session_salt), session_shared_secret);
     let mut wrapping_key = [0u8; 32];
     session_hkdf.expand(info, &mut wrapping_key)?;
 
@@ -91,14 +98,31 @@ mod tests {
     fn test_rewrap_dek() {
         let dek_secret = b"test_dek_shared_secret__32bytes!";
         let session_secret = b"test_session_shared_secret__32b!";
-        let salt = compute_nanotdf_salt(NanoTdfVersion::V12);
+        let dek_salt = compute_nanotdf_salt(NanoTdfVersion::V12);
+        let session_salt = compute_nanotdf_salt(NanoTdfVersion::V12);
 
-        let result = rewrap_dek(dek_secret, session_secret, &salt, b"");
+        let result = rewrap_dek(dek_secret, session_secret, &dek_salt, &session_salt, b"");
         assert!(result.is_ok());
 
         let (nonce, wrapped) = result.unwrap();
         assert_eq!(nonce.len(), 12);
         // Wrapped should be 32-byte DEK + 16-byte tag = 48 bytes
+        assert_eq!(wrapped.len(), 48);
+    }
+
+    #[test]
+    fn test_rewrap_dek_split_salts() {
+        let dek_secret = b"test_dek_shared_secret__32bytes!";
+        let session_secret = b"test_session_shared_secret__32b!";
+        // DEK uses v1.3 salt, session always uses v1.2 (matches Go reference KAS)
+        let dek_salt = compute_nanotdf_salt(NanoTdfVersion::V13);
+        let session_salt = compute_nanotdf_salt(NanoTdfVersion::V12);
+
+        let result = rewrap_dek(dek_secret, session_secret, &dek_salt, &session_salt, b"");
+        assert!(result.is_ok());
+
+        let (nonce, wrapped) = result.unwrap();
+        assert_eq!(nonce.len(), 12);
         assert_eq!(wrapped.len(), 48);
     }
 

--- a/crates/kas/src/unwrap/ec_unwrap.rs
+++ b/crates/kas/src/unwrap/ec_unwrap.rs
@@ -54,17 +54,23 @@ pub fn ec_unwrap(
     // Perform ECDH to get DEK shared secret
     let dek_shared_secret = custom_ecdh(kas_private_key, &ephemeral_public_key)?;
 
-    // Detect NanoTDF version and compute appropriate salt
-    let salt = match detect_nanotdf_version(header_bytes) {
+    // Detect NanoTDF version and compute DEK salt (version-dependent)
+    let dek_salt = match detect_nanotdf_version(header_bytes) {
         Some(version) => compute_nanotdf_salt(version),
         None => compute_nanotdf_salt(NanoTdfVersion::V12), // Default to v1.2
     };
+
+    // Session salt is always v1.2 — the session key exchange is a transport-layer
+    // concern, not a TDF-format concern. The Go reference KAS and all SDK clients
+    // (including OpenTDFKit) hardcode v1.2 salt for session key derivation.
+    let session_salt = compute_nanotdf_salt(NanoTdfVersion::V12);
 
     // Rewrap DEK using NanoTDF-compatible HKDF (empty info per spec)
     let (nonce, wrapped_dek) = rewrap_dek(
         &dek_shared_secret,
         session_shared_secret,
-        &salt,
+        &dek_salt,
+        &session_salt,
         b"", // Empty info per NanoTDF spec
     )?;
 


### PR DESCRIPTION
## Summary
- `rewrap_dek()` now takes separate `dek_salt` and `session_salt` parameters instead of a single `salt`
- `ec_unwrap()` hardcodes v1.2 salt for session key derivation, matching the Go reference KAS and all SDK clients
- Fixes session key mismatch when processing v1.3 NanoTDFs — the session key exchange is transport-layer, not format-dependent

## Test plan
- [x] All 16 existing `opentdf-kas` tests pass
- [x] New `test_rewrap_dek_split_salts` test covers v1.3 DEK salt + v1.2 session salt
- [ ] Verify interop with OpenTDFKit client after arkavo-rs updates to new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)