### PR TITLE
ci: add restrictive permissions to feature.yaml workflow

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `.github/workflows/feature.yaml`, resolving CodeQL alerts #1-#6 (`actions/missing-workflow-permissions`).
- No version bump — Cargo.toml versions are reserved for feature releases.

The 5 remaining CodeQL alerts (#7-#11, `rust/hard-coded-cryptographic-value`) flag IV literals inside unit/integration tests for `CollectionItem` — these are test fixtures that intentionally hardcode IVs to verify roundtrip encoding (e.g., `0x010203 → [0x01, 0x02, 0x03]`), not production cryptographic use. These will be dismissed as "used in tests" after merge.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)