### PR TITLE
feat(kas)!: migrate to ConnectRPC with well-known discovery (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## [0.13.0] — 2026-05-28
+
+### Breaking changes
+
+- `KasClient::new` now takes `&OpentdfConfiguration` instead of a base URL string. Migrate via:
+  ```rust
+  // before
+  let client = KasClient::new("https://kas.example.com", token)?;
+
+  // after
+  let cfg = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+      "https://kas.example.com",
+  );
+  let client = KasClient::new(&cfg, token)?;
+  ```
+  For discovery-driven setups, use `fetch_well_known(platform_url, &http).await?` to obtain the config.
+
+### Added
+
+- `opentdf::kas_discovery` module:
+  - `OpentdfConfiguration` deserialization of `/.well-known/opentdf-configuration`
+  - `KasEndpoints::from_config` with Connect-preferred / REST-fallback URL resolution
+  - `OpentdfConfiguration::for_kas_connect` / `for_kas_legacy_rest` direct builders
+  - `fetch_well_known` async discovery
+  - `parse_connect_error` Connect error envelope parser
+- `opentdf::kas_key::fetch_kas_public_key_connect` and `fetch_kas_ec_public_key_connect` for ConnectRPC public-key retrieval
+- Live ConnectRPC integration tests against `platform.arkavo.net` in `tests/platform_integration.rs` (`#[ignore]`d by default)
+- ConnectRPC route handlers in `examples/mock_kas_server.rs`
+
+### Changed
+
+- KAS rewrap now POSTs to `/kas.AccessService/Rewrap` (ConnectRPC) instead of `/kas/v2/rewrap` (legacy REST)
+- Connect error envelope (`{code, message}`) parsed into `KasError` reason strings
+
+### Deprecated
+
+- `opentdf::kas_key::fetch_kas_public_key` — use `fetch_kas_public_key_connect`
+- `opentdf::kas_key::fetch_kas_ec_public_key` — use `fetch_kas_ec_public_key_connect`
+
+### Notes
+
+- The `oauth_token` parameter of `KasClient::new` is an opaque passthrough. Pass a JWT or a base64url-encoded CWT; the server decides how to validate.
+- Closes [#85](https://github.com/arkavo-org/opentdf-rs/issues/85).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
 
 - KAS rewrap now POSTs to `/kas.AccessService/Rewrap` (ConnectRPC) instead of `/kas/v2/rewrap` (legacy REST)
 - Connect error envelope (`{code, message}`) parsed into `KasError` reason strings
+- KAS URL validation moved into `KasEndpoints::from_config`, which now validates **both** the resolved rewrap and public-key URLs (exposed as `kas_discovery::validate_kas_url`). This closes an SSRF gap where a remotely-fetched well-known document could otherwise redirect the bearer-carrying rewrap request at an internal target.
+
+### Security
+
+- SSRF URL validation now rejects IPv6 unique-local (`fc00::/7`) and link-local (`fe80::/10`) addresses, and folds IPv4-mapped IPv6 literals (e.g. `::ffff:169.254.169.254`) back to IPv4 so they can't bypass the metadata/private-range checks.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Security
 
 - SSRF URL validation now rejects IPv6 unique-local (`fc00::/7`) and link-local (`fe80::/10`) addresses, unspecified addresses (`0.0.0.0`, `::`), and folds IPv4-mapped IPv6 literals (e.g. `::ffff:169.254.169.254`) back to IPv4 so they can't bypass the metadata/private-range checks.
+- The KAS rewrap HTTP client now follows no redirects (`redirect::Policy::none()`), so a 3xx from a validated host cannot re-issue the bearer-carrying rewrap request to an unvalidated target (URL validation only runs on the initial URL, not per redirect hop).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ### Security
 
-- SSRF URL validation now rejects IPv6 unique-local (`fc00::/7`) and link-local (`fe80::/10`) addresses, and folds IPv4-mapped IPv6 literals (e.g. `::ffff:169.254.169.254`) back to IPv4 so they can't bypass the metadata/private-range checks.
+- SSRF URL validation now rejects IPv6 unique-local (`fc00::/7`) and link-local (`fe80::/10`) addresses, unspecified addresses (`0.0.0.0`, `::`), and folds IPv4-mapped IPv6 literals (e.g. `::ffff:169.254.169.254`) back to IPv4 so they can't bypass the metadata/private-range checks.
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ aes-gcm.workspace = true
 # KAS client dependencies (simplified, crypto moved to opentdf-crypto)
 reqwest = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
-jsonwebtoken = { version = "9", optional = true }
+jsonwebtoken = { version = "10", optional = true, features = ["aws_lc_rs"] }
 rand = { workspace = true, optional = true }
 # RSA operations use aws-lc-rs (constant-time, FIPS validated)
 aws-lc-rs = { version = "1.15", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 
 [dependencies]
 # New modular crates
-opentdf-protocol = { path = "crates/protocol", version = "0.12.0" }
-opentdf-crypto = { path = "crates/crypto", version = "0.12.0", default-features = false }
+opentdf-protocol = { path = "crates/protocol", version = "0.13.0" }
+opentdf-crypto = { path = "crates/crypto", version = "0.13.0", default-features = false }
 
 # Core dependencies (using workspace versions)
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
@@ -68,7 +68,7 @@ ciborium = "0.2"
 members = ["crates/protocol", "crates/crypto", "crates/kas", "crates/wasm"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 
 [workspace.dependencies]
 # Core serialization

--- a/README.md
+++ b/README.md
@@ -318,21 +318,38 @@ The KAS client is enabled by default:
 
 ```toml
 [dependencies]
-opentdf = "0.7"
+opentdf = "0.13"
+```
+
+#### Creating a KAS Client (v0.13+)
+
+`KasClient::new` accepts an `&OpentdfConfiguration` rather than a raw URL string.
+
+```rust
+use opentdf::kas::KasClient;
+use opentdf::kas_discovery::{fetch_well_known, OpentdfConfiguration};
+
+// Discovery (recommended): reads /.well-known/opentdf-configuration from the platform
+let http = reqwest::Client::new();
+let cfg = fetch_well_known("https://platform.arkavo.net", &http).await?;
+let kas = KasClient::new(&cfg, oauth_token)?;
+
+// Direct (skip discovery): build config from a known KAS URL
+let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+let kas = KasClient::new(&cfg, oauth_token)?;
 ```
 
 #### Decrypt TDF with KAS
 
 ```rust
 use opentdf::{TdfArchive, kas::KasClient};
+use opentdf::kas_discovery::OpentdfConfiguration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create KAS client
-    let kas_client = KasClient::new(
-        "https://kas.example.com/kas",
-        "your-oauth-token-here"
-    )?;
+    // Create KAS client (ConnectRPC transport)
+    let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+    let kas_client = KasClient::new(&cfg, "your-oauth-token-here")?;
 
     // Open and decrypt TDF in one call
     let plaintext = TdfArchive::open_and_decrypt(
@@ -351,14 +368,13 @@ For more control over the decryption process:
 
 ```rust
 use opentdf::{TdfArchive, kas::KasClient};
+use opentdf::kas_discovery::OpentdfConfiguration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create KAS client
-    let kas_client = KasClient::new(
-        "https://kas.example.com/kas",
-        "your-oauth-token-here"
-    )?;
+    // Create KAS client (ConnectRPC transport)
+    let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+    let kas_client = KasClient::new(&cfg, "your-oauth-token-here")?;
 
     // Open TDF archive
     let mut archive = TdfArchive::open("encrypted-file.tdf")?;

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The KAS protocol allows:
 1. Client generates ephemeral EC key pair (P-256)
 2. Client builds rewrap request with TDF manifest
 3. Client signs request with JWT (ES256)
-4. Client POSTs to KAS /v2/rewrap endpoint
+4. Client POSTs to KAS /kas.AccessService/Rewrap (ConnectRPC) endpoint
 5. KAS validates policy and user attributes
 6. KAS returns wrapped key + session public key
 7. Client unwraps key: ECDH → HKDF → AES-GCM decrypt
@@ -413,14 +413,14 @@ use opentdf::kas::{KasClient, KasError};
 
 match kas_client.rewrap_standard_tdf(&manifest).await {
     Ok(key) => println!("Successfully unwrapped key"),
-    Err(KasError::AccessDenied(reason)) => {
-        eprintln!("Access denied: {}", reason);
+    Err(KasError::AccessDenied { resource, reason }) => {
+        eprintln!("Access denied for {resource}: {reason}");
     }
-    Err(KasError::AuthenticationFailed) => {
-        eprintln!("Invalid OAuth token");
+    Err(KasError::AuthenticationFailed { reason }) => {
+        eprintln!("Auth failed: {reason}");
     }
-    Err(KasError::HttpError(msg)) => {
-        eprintln!("HTTP error: {}", msg);
+    Err(KasError::HttpError { status, message }) => {
+        eprintln!("HTTP {status}: {message}");
     }
     Err(e) => {
         eprintln!("KAS error: {}", e);
@@ -609,7 +609,7 @@ Add to your Cargo.toml:
 
 ```toml
 [dependencies]
-opentdf = "0.7"
+opentdf = "0.13"
 ```
 
 ### Feature Flags
@@ -637,16 +637,16 @@ opentdf = "0.7"
 
 ```toml
 # Recommended: Secure defaults (aws-lc-rs + rustls)
-opentdf = "0.7"
+opentdf = "0.13"
 
 # Pure Rust: No C compiler needed (accepts timing vulnerability)
-opentdf = { version = "0.7", default-features = false, features = ["kas-client-rustcrypto"] }
+opentdf = { version = "0.13", default-features = false, features = ["kas-client-rustcrypto"] }
 
 # Native TLS: Use system TLS (OpenSSL on Linux, SecureTransport on macOS)
-opentdf = { version = "0.7", default-features = false, features = ["kas-client", "native-tls"] }
+opentdf = { version = "0.13", default-features = false, features = ["kas-client", "native-tls"] }
 
 # Minimal: Core TDF operations only (no KAS client, no async)
-opentdf = { version = "0.7", default-features = false }
+opentdf = { version = "0.13", default-features = false }
 ```
 
 #### WASM Note
@@ -672,14 +672,14 @@ Version 0.7.0 brings critical security improvements and better feature organizat
 opentdf = { version = "0.6", features = ["kas"] }
 
 # After (v0.7.0) - "kas" still works but is deprecated
-opentdf = "0.7"  # kas-client is now the default
+opentdf = "0.13"  # kas-client is now the default
 ```
 
 **Pure Rust Builds**:
 ```toml
 # Before (v0.6.x) - not available
 # After (v0.7.0) - explicit pure Rust option
-opentdf = { version = "0.7", default-features = false, features = ["kas-client-rustcrypto"] }
+opentdf = { version = "0.13", default-features = false, features = ["kas-client-rustcrypto"] }
 ```
 
 ## What's New in v0.5.0

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -36,7 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 # Protocol types (for NanoTDF)
-opentdf-protocol = { path = "../protocol", version = "0.12.0" }
+opentdf-protocol = { path = "../protocol", version = "0.13.0" }
 
 # KAS feature dependencies (EC, HKDF)
 p256 = { workspace = true, optional = true }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -26,8 +26,8 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-opentdf = { path = "../..", version = "0.12.0", default-features = false }
-opentdf-protocol = { path = "../protocol", version = "0.12.0" }
+opentdf = { path = "../..", version = "0.13.0", default-features = false }
+opentdf-protocol = { path = "../protocol", version = "0.13.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde.workspace = true

--- a/docs/superpowers/plans/2026-05-28-connectrpc-kas-migration.md
+++ b/docs/superpowers/plans/2026-05-28-connectrpc-kas-migration.md
@@ -1,0 +1,1851 @@
+# ConnectRPC KAS Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the native Rust KAS client from the legacy `/kas/v2/*` REST endpoints to the platform's canonical `/kas.AccessService/*` ConnectRPC endpoints, with URL selection driven by `/.well-known/opentdf-configuration` discovery.
+
+**Architecture:** New `src/kas_discovery.rs` owns the well-known doc deserialization and URL-resolution logic. `KasClient::new` becomes synchronous and takes a pre-resolved `&OpentdfConfiguration`. Discovery is a separate `fetch_well_known` async free function. Connect JSON envelope is hand-rolled — two unary RPCs, no protobuf codegen, zero new dependencies. The OAuth bearer is an opaque passthrough; the caller decides JWT vs base64url(CWT).
+
+**Tech Stack:** Rust 2024 edition, reqwest 0.12 (rustls), serde 1.0, mockito 1.6 (dev), aws-lc-rs 1.15 (RSA), jsonwebtoken 10, tokio 1.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-connectrpc-kas-migration-design.md`
+
+**Tracking issue:** [#85](https://github.com/arkavo-org/opentdf-rs/issues/85)
+
+---
+
+## File map
+
+| File | Status | Responsibility |
+|---|---|---|
+| `src/kas_discovery.rs` | **NEW** | `OpentdfConfiguration`, `KasConfig`, `IdpConfig`, `KasEndpoints`, `KasTransport`, `ConnectError`, `parse_connect_error`, `fetch_well_known` |
+| `src/lib.rs` | modify | export new `kas_discovery` module |
+| `src/kas.rs` | modify | `send_rewrap_request` URL, `KasClient::new` signature, struct field add |
+| `src/kas_key.rs` | modify | add Connect siblings, deprecate REST functions |
+| `src/tdf.rs` | modify | doc-comment migrations (doctests) |
+| `src/archive.rs` | modify | doc-comment migrations (doctests) |
+| `tests/kas_mock.rs` | modify | route paths, add Connect-error envelope test, add public-key Connect test, migrate constructor calls |
+| `tests/kas_integration.rs` | modify | migrate constructor calls |
+| `tests/platform_integration.rs` | modify | add Connect/well-known/CWT-401 live tests against `platform.arkavo.net` |
+| `examples/kas_decrypt.rs` | modify | constructor migration |
+| `examples/create_tdf_platform.rs` | modify | constructor migration, use `fetch_kas_public_key_connect` |
+| `examples/kas_sanity_test.rs` | modify | constructor migration, point at Connect path |
+| `examples/jwt_helper.rs` | modify | doc string in `println!` |
+| `examples/mock_kas_server.rs` | modify | add Connect route handlers alongside REST |
+| `Cargo.toml` (root + workspace + sub-crates) | modify | `0.12.0` → `0.13.0` |
+| `CHANGELOG.md` | modify (or create) | breaking change entry, migration one-liner |
+
+---
+
+## Task 1: Bootstrap `kas_discovery` module
+
+**Files:**
+- Create: `src/kas_discovery.rs`
+- Modify: `src/lib.rs`
+
+- [ ] **Step 1: Create the empty module file**
+
+Create `src/kas_discovery.rs`:
+
+```rust
+//! KAS endpoint discovery via /.well-known/opentdf-configuration
+//!
+//! Provides types for deserializing the platform's well-known configuration
+//! document, plus URL-resolution logic that prefers ConnectRPC endpoints
+//! and falls back to legacy REST paths when only REST is advertised.
+
+#![cfg(feature = "kas-client")]
+```
+
+- [ ] **Step 2: Export from lib.rs**
+
+In `src/lib.rs`, find the existing `pub mod kas;` and add immediately after:
+
+```rust
+pub mod kas_discovery;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build --features kas-client`
+Expected: clean build, no new warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/kas_discovery.rs src/lib.rs
+git commit -m "feat(kas): add empty kas_discovery module (#85)"
+```
+
+---
+
+## Task 2: `OpentdfConfiguration` deserialization
+
+**Files:**
+- Modify: `src/kas_discovery.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/kas_discovery.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from https://platform.arkavo.net/.well-known/opentdf-configuration on 2026-05-28
+    const PLATFORM_WELL_KNOWN: &str = r#"{
+        "health": { "endpoint": "/healthz" },
+        "idp": {
+            "access_token_format": "application/cwt",
+            "authorization_endpoint": "https://identity.arkavo.net/oauth/authorize",
+            "cose_keys_uri": "https://identity.arkavo.net/.well-known/cose-keys",
+            "id_token_signing_alg_values_supported": ["ES256"],
+            "issuer": "https://identity.arkavo.net",
+            "jwks_uri": "https://identity.arkavo.net/.well-known/jwks.json",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "token_endpoint": "https://identity.arkavo.net/oauth/token",
+            "userinfo_endpoint": "https://identity.arkavo.net/oauth/userinfo"
+        },
+        "kas": {
+            "algorithms": ["ec:secp256r1", "rsa:2048"],
+            "connect_public_key_url": "https://platform.arkavo.net/kas.AccessService/PublicKey",
+            "connect_rewrap_url": "https://platform.arkavo.net/kas.AccessService/Rewrap",
+            "public_key_url": "https://platform.arkavo.net/kas/v2/kas_public_key",
+            "rewrap_url": "https://platform.arkavo.net/kas/v2/rewrap",
+            "uri": "https://platform.arkavo.net"
+        },
+        "platform_issuer": "https://identity.arkavo.net"
+    }"#;
+
+    #[test]
+    fn deserializes_platform_well_known() {
+        let cfg: OpentdfConfiguration = serde_json::from_str(PLATFORM_WELL_KNOWN).unwrap();
+        let kas = cfg.kas.expect("kas block present");
+        assert_eq!(kas.uri, "https://platform.arkavo.net");
+        assert_eq!(kas.algorithms, vec!["ec:secp256r1", "rsa:2048"]);
+        assert_eq!(
+            kas.connect_rewrap_url.as_deref(),
+            Some("https://platform.arkavo.net/kas.AccessService/Rewrap")
+        );
+        assert_eq!(
+            kas.rewrap_url.as_deref(),
+            Some("https://platform.arkavo.net/kas/v2/rewrap")
+        );
+        let idp = cfg.idp.expect("idp block present");
+        assert_eq!(idp.issuer, "https://identity.arkavo.net");
+        assert_eq!(idp.access_token_format.as_deref(), Some("application/cwt"));
+        assert_eq!(cfg.platform_issuer.as_deref(), Some("https://identity.arkavo.net"));
+    }
+
+    #[test]
+    fn deserializes_minimal_kas_only() {
+        let json = r#"{
+            "kas": {
+                "uri": "https://k.example.com",
+                "algorithms": [],
+                "rewrap_url": "https://k.example.com/kas/v2/rewrap",
+                "public_key_url": "https://k.example.com/kas/v2/kas_public_key"
+            }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let kas = cfg.kas.unwrap();
+        assert!(kas.connect_rewrap_url.is_none());
+        assert_eq!(kas.rewrap_url.as_deref(), Some("https://k.example.com/kas/v2/rewrap"));
+        assert!(cfg.idp.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --features kas-client kas_discovery::tests::deserializes`
+Expected: FAIL — `OpentdfConfiguration` and related types don't exist yet.
+
+- [ ] **Step 3: Implement the types**
+
+In `src/kas_discovery.rs`, insert before `#[cfg(test)]`:
+
+```rust
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpentdfConfiguration {
+    pub kas: Option<KasConfig>,
+    pub idp: Option<IdpConfig>,
+    pub platform_issuer: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KasConfig {
+    pub uri: String,
+    #[serde(default)]
+    pub algorithms: Vec<String>,
+    pub public_key_url: Option<String>,
+    pub rewrap_url: Option<String>,
+    pub connect_public_key_url: Option<String>,
+    pub connect_rewrap_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdpConfig {
+    pub issuer: String,
+    pub jwks_uri: Option<String>,
+    pub cose_keys_uri: Option<String>,
+    pub token_endpoint: Option<String>,
+    pub authorization_endpoint: Option<String>,
+    pub userinfo_endpoint: Option<String>,
+    pub access_token_format: Option<String>,
+    #[serde(default)]
+    pub id_token_signing_alg_values_supported: Vec<String>,
+    #[serde(default)]
+    pub response_types_supported: Vec<String>,
+    #[serde(default)]
+    pub subject_types_supported: Vec<String>,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --features kas-client kas_discovery::tests::deserializes`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kas_discovery.rs
+git commit -m "feat(kas): add OpentdfConfiguration deserialization (#85)"
+```
+
+---
+
+## Task 3: `KasEndpoints::from_config` URL selection
+
+**Files:**
+- Modify: `src/kas_discovery.rs`
+
+- [ ] **Step 1: Add failing tests**
+
+In the existing `mod tests` block in `src/kas_discovery.rs`, add:
+
+```rust
+    #[test]
+    fn from_config_picks_connect_when_present() {
+        let cfg: OpentdfConfiguration = serde_json::from_str(PLATFORM_WELL_KNOWN).unwrap();
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://platform.arkavo.net/kas.AccessService/Rewrap"
+        );
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://platform.arkavo.net/kas.AccessService/PublicKey"
+        );
+        assert_eq!(endpoints.transport, KasTransport::Connect);
+    }
+
+    #[test]
+    fn from_config_falls_back_to_rest_when_connect_absent() {
+        let json = r#"{
+            "kas": {
+                "uri": "https://k.example.com",
+                "algorithms": [],
+                "rewrap_url": "https://k.example.com/kas/v2/rewrap",
+                "public_key_url": "https://k.example.com/kas/v2/kas_public_key"
+            }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(endpoints.rewrap_url, "https://k.example.com/kas/v2/rewrap");
+        assert_eq!(endpoints.public_key_url, "https://k.example.com/kas/v2/kas_public_key");
+        assert_eq!(endpoints.transport, KasTransport::LegacyRest);
+    }
+
+    #[test]
+    fn from_config_errors_when_kas_block_missing() {
+        let json = r#"{ "platform_issuer": "https://example.com" }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let err = KasEndpoints::from_config(&cfg).unwrap_err();
+        match err {
+            opentdf_protocol::KasError::ConfigError { reason } => {
+                assert!(reason.contains("kas"));
+            }
+            other => panic!("expected ConfigError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_config_errors_when_urls_missing() {
+        let json = r#"{
+            "kas": { "uri": "https://k.example.com", "algorithms": [] }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let err = KasEndpoints::from_config(&cfg).unwrap_err();
+        assert!(matches!(err, opentdf_protocol::KasError::ConfigError { .. }));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --features kas-client kas_discovery::tests::from_config`
+Expected: FAIL — `KasEndpoints` / `KasTransport` undefined.
+
+- [ ] **Step 3: Implement `KasEndpoints` and `KasTransport`**
+
+In `src/kas_discovery.rs`, after the existing types:
+
+```rust
+use opentdf_protocol::KasError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KasTransport {
+    /// ConnectRPC endpoints at /kas.AccessService/*
+    Connect,
+    /// Legacy REST gateway at /kas/v2/*
+    LegacyRest,
+}
+
+#[derive(Debug, Clone)]
+pub struct KasEndpoints {
+    pub rewrap_url: String,
+    pub public_key_url: String,
+    pub transport: KasTransport,
+}
+
+impl KasEndpoints {
+    /// Resolve KAS endpoints from a configuration document, preferring
+    /// ConnectRPC URLs and falling back to legacy REST when only REST is
+    /// advertised.
+    pub fn from_config(cfg: &OpentdfConfiguration) -> Result<Self, KasError> {
+        let kas = cfg.kas.as_ref().ok_or_else(|| KasError::ConfigError {
+            reason: "well-known configuration is missing a 'kas' block".to_string(),
+        })?;
+
+        if let (Some(rewrap), Some(public_key)) =
+            (&kas.connect_rewrap_url, &kas.connect_public_key_url)
+        {
+            return Ok(KasEndpoints {
+                rewrap_url: rewrap.clone(),
+                public_key_url: public_key.clone(),
+                transport: KasTransport::Connect,
+            });
+        }
+
+        if let (Some(rewrap), Some(public_key)) = (&kas.rewrap_url, &kas.public_key_url) {
+            return Ok(KasEndpoints {
+                rewrap_url: rewrap.clone(),
+                public_key_url: public_key.clone(),
+                transport: KasTransport::LegacyRest,
+            });
+        }
+
+        Err(KasError::ConfigError {
+            reason: "well-known kas block exposes neither Connect nor REST URLs".to_string(),
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --features kas-client kas_discovery::tests::from_config`
+Expected: PASS, all four tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kas_discovery.rs
+git commit -m "feat(kas): KasEndpoints::from_config URL selection (#85)"
+```
+
+---
+
+## Task 4: `for_kas_connect` / `for_kas_legacy_rest` builders
+
+**Files:**
+- Modify: `src/kas_discovery.rs`
+
+- [ ] **Step 1: Add failing tests**
+
+In the existing `mod tests` block:
+
+```rust
+    #[test]
+    fn for_kas_connect_constructs_expected_urls() {
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://kas.example.com/kas.AccessService/Rewrap"
+        );
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://kas.example.com/kas.AccessService/PublicKey"
+        );
+        assert_eq!(endpoints.transport, KasTransport::Connect);
+    }
+
+    #[test]
+    fn for_kas_connect_handles_trailing_slash() {
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com/");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://kas.example.com/kas.AccessService/Rewrap"
+        );
+    }
+
+    #[test]
+    fn for_kas_legacy_rest_constructs_expected_urls() {
+        let cfg = OpentdfConfiguration::for_kas_legacy_rest("https://kas.example.com");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(endpoints.rewrap_url, "https://kas.example.com/kas/v2/rewrap");
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://kas.example.com/kas/v2/kas_public_key"
+        );
+        assert_eq!(endpoints.transport, KasTransport::LegacyRest);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --features kas-client kas_discovery::tests::for_kas`
+Expected: FAIL — `for_kas_connect` / `for_kas_legacy_rest` don't exist.
+
+- [ ] **Step 3: Implement the builders**
+
+In `src/kas_discovery.rs`, add an `impl OpentdfConfiguration` block:
+
+```rust
+impl OpentdfConfiguration {
+    /// Synthesize a configuration document pointing at a single KAS base URL
+    /// using ConnectRPC paths. Use this when you can't or don't want to fetch
+    /// `/.well-known/opentdf-configuration` (e.g., tests, deployments that
+    /// don't expose the well-known endpoint).
+    pub fn for_kas_connect(base_url: impl Into<String>) -> Self {
+        let base = base_url.into();
+        let base = base.trim_end_matches('/').to_string();
+        Self {
+            kas: Some(KasConfig {
+                uri: base.clone(),
+                algorithms: vec![],
+                public_key_url: None,
+                rewrap_url: None,
+                connect_public_key_url: Some(format!("{}/kas.AccessService/PublicKey", base)),
+                connect_rewrap_url: Some(format!("{}/kas.AccessService/Rewrap", base)),
+            }),
+            idp: None,
+            platform_issuer: None,
+        }
+    }
+
+    /// Synthesize a configuration document pointing at a single KAS base URL
+    /// using legacy REST paths. Escape hatch for deployments that haven't
+    /// migrated to ConnectRPC.
+    pub fn for_kas_legacy_rest(base_url: impl Into<String>) -> Self {
+        let base = base_url.into();
+        let base = base.trim_end_matches('/').to_string();
+        Self {
+            kas: Some(KasConfig {
+                uri: base.clone(),
+                algorithms: vec![],
+                public_key_url: Some(format!("{}/kas/v2/kas_public_key", base)),
+                rewrap_url: Some(format!("{}/kas/v2/rewrap", base)),
+                connect_public_key_url: None,
+                connect_rewrap_url: None,
+            }),
+            idp: None,
+            platform_issuer: None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --features kas-client kas_discovery::tests::for_kas`
+Expected: PASS, all three tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kas_discovery.rs
+git commit -m "feat(kas): OpentdfConfiguration builders for direct construction (#85)"
+```
+
+---
+
+## Task 5: Connect error envelope parser
+
+**Files:**
+- Modify: `src/kas_discovery.rs`
+
+- [ ] **Step 1: Add failing tests**
+
+In the existing `mod tests` block:
+
+```rust
+    #[test]
+    fn parse_connect_error_with_valid_body() {
+        let body = r#"{"code":"unauthenticated","message":"missing bearer token"}"#;
+        let err = parse_connect_error(body).unwrap();
+        assert_eq!(err.code, "unauthenticated");
+        assert_eq!(err.message, "missing bearer token");
+    }
+
+    #[test]
+    fn parse_connect_error_with_garbage_returns_none() {
+        assert!(parse_connect_error("not json").is_none());
+        assert!(parse_connect_error("").is_none());
+        assert!(parse_connect_error(r#"{"unrelated":"shape"}"#).is_none());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --features kas-client kas_discovery::tests::parse_connect_error`
+Expected: FAIL — `ConnectError` / `parse_connect_error` don't exist.
+
+- [ ] **Step 3: Implement parser**
+
+In `src/kas_discovery.rs`, after the `impl OpentdfConfiguration` block:
+
+```rust
+/// Error envelope returned by Connect unary-JSON RPCs on non-2xx responses.
+///
+/// Codes are defined by the Connect protocol spec
+/// (canceled, unknown, invalid_argument, deadline_exceeded, not_found,
+/// already_exists, permission_denied, resource_exhausted, failed_precondition,
+/// aborted, out_of_range, unimplemented, internal, unavailable, data_loss,
+/// unauthenticated).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConnectError {
+    pub code: String,
+    pub message: String,
+}
+
+/// Attempt to parse a Connect error envelope from a response body.
+/// Returns `None` for empty bodies, non-JSON bodies, or JSON that doesn't
+/// match the Connect error shape.
+pub fn parse_connect_error(body: &str) -> Option<ConnectError> {
+    if body.is_empty() {
+        return None;
+    }
+    let parsed: ConnectError = serde_json::from_str(body).ok()?;
+    // Reject objects that happen to deserialize but lack meaningful content
+    if parsed.code.is_empty() {
+        return None;
+    }
+    Some(parsed)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --features kas-client kas_discovery::tests::parse_connect_error`
+Expected: PASS, both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/kas_discovery.rs
+git commit -m "feat(kas): parse Connect error envelope (#85)"
+```
+
+---
+
+## Task 6: `fetch_well_known` async function
+
+**Files:**
+- Modify: `src/kas_discovery.rs`
+
+- [ ] **Step 1: Add failing tests**
+
+In the existing `mod tests` block:
+
+```rust
+    use mockito::Server;
+
+    #[tokio::test]
+    async fn fetch_well_known_returns_parsed_config() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(PLATFORM_WELL_KNOWN)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cfg = fetch_well_known(&server.url(), &http).await.unwrap();
+        assert!(cfg.kas.is_some());
+        assert_eq!(
+            cfg.platform_issuer.as_deref(),
+            Some("https://identity.arkavo.net")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_well_known_404_returns_http_error() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let err = fetch_well_known(&server.url(), &http).await.unwrap_err();
+        match err {
+            opentdf_protocol::KasError::HttpError { status, .. } => assert_eq!(status, 404),
+            other => panic!("expected HttpError(404), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_well_known_handles_trailing_slash() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(200)
+            .with_body(PLATFORM_WELL_KNOWN)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let url_with_slash = format!("{}/", server.url());
+        let cfg = fetch_well_known(&url_with_slash, &http).await.unwrap();
+        assert!(cfg.kas.is_some());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --features kas-client kas_discovery::tests::fetch_well_known`
+Expected: FAIL — function undefined.
+
+- [ ] **Step 3: Implement `fetch_well_known`**
+
+In `src/kas_discovery.rs`, after `parse_connect_error`:
+
+```rust
+/// Fetch the platform's `/.well-known/opentdf-configuration` document.
+///
+/// `platform_url` should be the platform's base URL (e.g.,
+/// `"https://platform.arkavo.net"`). A trailing slash is tolerated.
+pub async fn fetch_well_known(
+    platform_url: &str,
+    http_client: &reqwest::Client,
+) -> Result<OpentdfConfiguration, KasError> {
+    let base = platform_url.trim_end_matches('/');
+    let url = format!("{}/.well-known/opentdf-configuration", base);
+
+    let response = http_client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| KasError::RequestError {
+            method: "GET".to_string(),
+            url: url.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(KasError::HttpError {
+            status: status.as_u16(),
+            message: format!("GET {} -> {}: {}", url, status, body),
+        });
+    }
+
+    response
+        .json::<OpentdfConfiguration>()
+        .await
+        .map_err(|e| KasError::InvalidResponse {
+            reason: format!("Failed to parse well-known JSON: {}", e),
+            expected: Some("OpentdfConfiguration".to_string()),
+        })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --features kas-client kas_discovery::tests::fetch_well_known`
+Expected: PASS, all three tests.
+
+- [ ] **Step 5: Run full discovery test suite**
+
+Run: `cargo test --features kas-client kas_discovery::`
+Expected: PASS — all discovery module tests green (deserialization + endpoints + builders + parse_connect_error + fetch_well_known).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/kas_discovery.rs
+git commit -m "feat(kas): fetch_well_known async discovery function (#85)"
+```
+
+---
+
+## Task 7: Switch `send_rewrap_request` to Connect URL + parse Connect errors
+
+This task keeps the existing `KasClient::new(base_url, oauth_token)` signature unchanged — the URL change is internal to `send_rewrap_request`. The constructor signature change comes in Task 8 so each commit compiles cleanly.
+
+**Files:**
+- Modify: `src/kas.rs`
+- Modify: `tests/kas_mock.rs`
+
+- [ ] **Step 1: Update mock test paths**
+
+In `tests/kas_mock.rs`, replace **every** occurrence of `"/kas/v2/rewrap"` with `"/kas.AccessService/Rewrap"`. There are six occurrences at lines 76, 110, 139, 166, 193, 284. Update the comment at line 92 from "The client will append /kas/v2/rewrap to its base_url" to "The client will append /kas.AccessService/Rewrap to its base_url".
+
+- [ ] **Step 2: Add a Connect 401 envelope test**
+
+In `tests/kas_mock.rs`, inside `mod kas_mock_tests`, add this new test after `test_kas_authentication_failure`:
+
+```rust
+    #[tokio::test]
+    async fn test_kas_connect_401_envelope_surfaced_in_error() {
+        let mut server = Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/kas.AccessService/Rewrap")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"code":"unauthenticated","message":"missing bearer token"}"#)
+            .create();
+
+        let kas_url = server.url();
+        let client = KasClient::new(&kas_url, "bad-token").unwrap();
+        let manifest = create_test_manifest_with_policy(kas_url.clone());
+
+        let result = client.rewrap_standard_tdf(&manifest).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unauthenticated") || msg.contains("missing bearer token"),
+            "expected Connect error code/message in error string, got: {msg}"
+        );
+    }
+```
+
+- [ ] **Step 3: Run the existing tests to verify they fail**
+
+Run: `cargo test --features kas-client --test kas_mock`
+Expected: existing tests FAIL because `send_rewrap_request` still POSTs to `/kas/v2/rewrap` (404 against the new mock paths).
+
+- [ ] **Step 4: Update `send_rewrap_request` in `src/kas.rs`**
+
+In `src/kas.rs`, locate `async fn send_rewrap_request` (around line 288). Replace the function body with:
+
+```rust
+    /// Internal helper for sending signed rewrap requests to KAS via ConnectRPC
+    ///
+    /// Handles HTTP POST to /kas.AccessService/Rewrap, parses Connect error
+    /// envelopes for richer error messages, and deserializes the response.
+    async fn send_rewrap_request(
+        &self,
+        signed_request: &SignedRewrapRequest,
+    ) -> Result<RewrapResponse, KasError> {
+        let rewrap_endpoint = format!("{}/kas.AccessService/Rewrap", self.base_url);
+
+        let response = self
+            .http_client
+            .post(&rewrap_endpoint)
+            .header("Authorization", format!("Bearer {}", self.oauth_token))
+            .header("Content-Type", "application/json")
+            .json(signed_request)
+            .send()
+            .await
+            .map_err(|e| KasError::HttpError {
+                status: 0,
+                message: format!("HTTP request failed: {}", e),
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            let detail = crate::kas_discovery::parse_connect_error(&error_body)
+                .map(|e| format!("{}: {}", e.code, e.message))
+                .unwrap_or_else(|| {
+                    if error_body.is_empty() {
+                        format!("HTTP {}", status)
+                    } else {
+                        error_body.clone()
+                    }
+                });
+
+            return Err(match status.as_u16() {
+                401 => KasError::AuthenticationFailed { reason: detail },
+                403 => KasError::AccessDenied {
+                    resource: "KAS endpoint".to_string(),
+                    reason: detail,
+                },
+                _ => KasError::HttpError {
+                    status: status.as_u16(),
+                    message: detail,
+                },
+            });
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|e| KasError::InvalidResponse {
+                reason: format!("Failed to parse JSON response: {}", e),
+                expected: Some("RewrapResponse".to_string()),
+            })
+    }
+```
+
+- [ ] **Step 5: Update the doc comments in `src/kas.rs`**
+
+In `src/kas.rs`, update the module-level doc comments. At line 12 and line 20, change `4. POST to KAS `/v2/rewrap` endpoint` to `4. POST to KAS `/kas.AccessService/Rewrap` (ConnectRPC) endpoint`. At line 340 in the `rewrap_standard_tdf` doc, change `4. POST to KAS /v2/rewrap endpoint with signed JWT` to `4. POST to KAS /kas.AccessService/Rewrap (ConnectRPC) endpoint with signed JWT`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --features kas-client --test kas_mock`
+Expected: PASS, all eight tests (six existing + one new Connect 401 envelope test + existing JWT-format test).
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cargo test --all-features`
+Expected: PASS. The transport change is internal; downstream tests should be unaffected.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/kas.rs tests/kas_mock.rs
+git commit -m "feat(kas): switch send_rewrap_request to ConnectRPC + parse Connect errors (#85)"
+```
+
+---
+
+## Task 8: `KasClient::new` takes `&OpentdfConfiguration` (breaking change)
+
+This task is the breaking change. All call sites in the workspace must update in the same commit, otherwise the tree won't compile.
+
+**Files:**
+- Modify: `src/kas.rs`
+- Modify: `src/tdf.rs`
+- Modify: `src/archive.rs`
+- Modify: `tests/kas_mock.rs`
+- Modify: `tests/kas_integration.rs`
+- Modify: `examples/kas_decrypt.rs`
+- Modify: `examples/create_tdf_platform.rs` (constructor only; public-key fetch updated in Task 10)
+- Modify: `examples/kas_sanity_test.rs`
+- Modify: `examples/jwt_helper.rs`
+
+- [ ] **Step 1: Update `KasClient` struct and `new` in `src/kas.rs`**
+
+In `src/kas.rs`, locate the `KasClient` struct (around line 177). Replace it with:
+
+```rust
+#[cfg(feature = "kas-client")]
+pub struct KasClient {
+    http_client: Client,
+    pub base_url: String,
+    endpoints: crate::kas_discovery::KasEndpoints,
+    oauth_token: String,
+    signing_key: PrivateDecryptingKey,
+}
+```
+
+Then replace the `impl KasClient` `new` function (around line 206-283):
+
+```rust
+    /// Create a new KAS client from a resolved configuration document.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A pre-resolved `OpentdfConfiguration`. Obtain via
+    ///   `fetch_well_known(...)` for discovery-driven setups, or build
+    ///   directly with `OpentdfConfiguration::for_kas_connect(base_url)`
+    ///   when the platform doesn't expose `/.well-known/opentdf-configuration`.
+    ///   `OpentdfConfiguration::for_kas_legacy_rest(base_url)` is the escape
+    ///   hatch for pre-ConnectRPC deployments.
+    /// * `oauth_token` - Bearer token sent in the `Authorization` header.
+    ///   Opaque passthrough: pass a JWT or a base64url-encoded CWT — the
+    ///   server decides how to validate.
+    ///
+    /// # Security
+    ///
+    /// The resolved KAS rewrap URL is validated:
+    /// - **HTTPS required**: HTTP is only allowed for `localhost`/`127.0.0.1`/`::1` (development use)
+    /// - **SSRF protection**: Private and link-local IP addresses are rejected
+    /// - **Scheme validation**: Only `http` and `https` schemes are accepted
+    ///
+    /// # Note
+    ///
+    /// This client generates an ephemeral RSA-2048 key pair for signing the
+    /// inner JWT rewrap request envelope. That is separate from the access
+    /// token — the inner JWT is the rewrap-request signature; the `oauth_token`
+    /// is the platform-issued access token.
+    pub fn new(
+        config: &crate::kas_discovery::OpentdfConfiguration,
+        oauth_token: impl Into<String>,
+    ) -> Result<Self, KasError> {
+        let endpoints = crate::kas_discovery::KasEndpoints::from_config(config)?;
+
+        // Validate the rewrap URL — the public_key_url is validated on use.
+        Self::validate_kas_url(&endpoints.rewrap_url)?;
+
+        let http_client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| KasError::HttpError {
+                status: 0,
+                message: format!("Failed to build HTTP client: {}", e),
+            })?;
+
+        let signing_key = PrivateDecryptingKey::generate(KeySize::Rsa2048).map_err(|e| {
+            KasError::CryptoError {
+                operation: "generate_signing_key".to_string(),
+                reason: format!("Failed to generate RSA signing key: {:?}", e),
+            }
+        })?;
+
+        // Derive base_url from the kas block's `uri` if present, else from the
+        // rewrap URL host. Used only for backwards-compat field access; not
+        // used for routing (we use endpoints.rewrap_url).
+        let base_url = config
+            .kas
+            .as_ref()
+            .map(|k| k.uri.trim_end_matches('/').to_string())
+            .unwrap_or_default();
+
+        Ok(Self {
+            http_client,
+            base_url,
+            endpoints,
+            oauth_token: oauth_token.into(),
+            signing_key,
+        })
+    }
+
+    /// Validate a KAS URL for HTTPS / SSRF / scheme constraints.
+    fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
+        let parsed = url::Url::parse(url_str)
+            .map_err(|e| KasError::InvalidUrl(format!("Failed to parse URL: {e}")))?;
+
+        match parsed.scheme() {
+            "https" => {}
+            "http" => {
+                let is_loopback = match parsed.host() {
+                    Some(url::Host::Domain("localhost")) => true,
+                    Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+                    Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+                    _ => false,
+                };
+                if !is_loopback {
+                    return Err(KasError::InvalidUrl(
+                        "KAS URL must use HTTPS (HTTP only allowed for localhost)".to_string(),
+                    ));
+                }
+            }
+            scheme => {
+                return Err(KasError::InvalidUrl(format!(
+                    "Unsupported URL scheme '{scheme}', must be https"
+                )));
+            }
+        }
+
+        if let Some(host) = parsed.host() {
+            match host {
+                url::Host::Ipv4(ip) => {
+                    if ip.is_private() || ip.is_link_local() {
+                        return Err(KasError::InvalidUrl(
+                            "KAS URL must not target private or link-local IP addresses"
+                                .to_string(),
+                        ));
+                    }
+                }
+                url::Host::Ipv6(_) | url::Host::Domain(_) => {}
+            }
+        }
+
+        Ok(())
+    }
+```
+
+- [ ] **Step 2: Update `send_rewrap_request` to use `endpoints.rewrap_url`**
+
+In `src/kas.rs`, in `send_rewrap_request`, change the URL line from:
+
+```rust
+        let rewrap_endpoint = format!("{}/kas.AccessService/Rewrap", self.base_url);
+```
+
+to:
+
+```rust
+        let rewrap_endpoint = self.endpoints.rewrap_url.clone();
+```
+
+- [ ] **Step 3: Update the `KasClient` doc example in `src/kas.rs`**
+
+Replace the example at lines 30-49 in `src/kas.rs`:
+
+```rust
+//! # Example
+//!
+//! ```no_run
+//! use opentdf::kas::KasClient;
+//! use opentdf::kas_discovery::OpentdfConfiguration;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+//! let client = KasClient::new(&config, "oauth_token_here")?;
+//!
+//! let manifest = opentdf::TdfManifest::new(
+//!     "0.payload".to_string(),
+//!     "https://kas.example.com".to_string()
+//! );
+//!
+//! let payload_key = client.rewrap_standard_tdf(&manifest).await?;
+//! # Ok(())
+//! # }
+//! ```
+```
+
+- [ ] **Step 4: Update `url_validation_tests` in `src/kas.rs`**
+
+In `src/kas.rs`, replace the entire `mod url_validation_tests` block (lines 869-954) with:
+
+```rust
+    #[cfg(feature = "kas-client")]
+    mod url_validation_tests {
+        use super::*;
+        use crate::kas_discovery::OpentdfConfiguration;
+
+        /// Helper: construct via for_kas_connect and capture the error.
+        fn expect_err(url: &str) -> KasError {
+            let cfg = OpentdfConfiguration::for_kas_connect(url);
+            match KasClient::new(&cfg, "token") {
+                Err(e) => e,
+                Ok(_) => panic!("Expected error for {url}, got Ok"),
+            }
+        }
+
+        #[test]
+        fn test_kas_rejects_http_url() {
+            let err = expect_err("http://evil.com");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
+            assert!(err.to_string().contains("HTTPS"));
+        }
+
+        #[test]
+        fn test_kas_accepts_https_url() {
+            let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+            assert!(KasClient::new(&cfg, "token").is_ok());
+        }
+
+        #[test]
+        fn test_kas_allows_http_localhost() {
+            for base in ["http://127.0.0.1:8080", "http://localhost:8080", "http://[::1]:8080"] {
+                let cfg = OpentdfConfiguration::for_kas_connect(base);
+                assert!(
+                    KasClient::new(&cfg, "token").is_ok(),
+                    "HTTP loopback {base} should be allowed"
+                );
+            }
+        }
+
+        #[test]
+        fn test_kas_rejects_private_ip() {
+            for base in ["https://10.0.0.1", "https://172.16.0.1", "https://192.168.1.1"] {
+                let err = expect_err(base);
+                assert!(matches!(err, KasError::InvalidUrl(_)), "{base}: {err}");
+            }
+        }
+
+        #[test]
+        fn test_kas_rejects_metadata_ip() {
+            let err = expect_err("http://169.254.169.254");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
+        }
+
+        #[test]
+        fn test_kas_rejects_invalid_scheme() {
+            let err = expect_err("ftp://kas.example.com");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
+            assert!(err.to_string().contains("ftp"));
+        }
+
+        #[test]
+        fn test_kas_rejects_invalid_url() {
+            let err = expect_err("not-a-url");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
+        }
+    }
+```
+
+- [ ] **Step 5: Update `tests/kas_mock.rs` constructor calls**
+
+In `tests/kas_mock.rs`, update the imports at line 9-13 to add `kas_discovery::OpentdfConfiguration`:
+
+```rust
+    use mockito::Server;
+    use opentdf::{
+        TdfManifest,
+        kas::{KasClient, KeyType},
+        kas_discovery::OpentdfConfiguration,
+        manifest::TdfManifestExt,
+    };
+```
+
+Then replace every `KasClient::new(&kas_url, "...")` and `KasClient::new(kas_url, ...)` call with:
+
+```rust
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "<token>").unwrap();
+```
+
+Six call sites (lines 66, 89, 117, 146, 173, 200, 219, 296). Use `.expect("create client")` instead of `.unwrap()` where the existing code uses `.unwrap()` — match the existing style at each site.
+
+For the `test_kas_client_creation` test at line 65, the new shape is:
+
+```rust
+    #[tokio::test]
+    async fn test_kas_client_creation() {
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+        let client = KasClient::new(&cfg, "mock-token");
+        assert!(client.is_ok(), "KAS client creation should succeed");
+    }
+```
+
+For `test_kas_network_timeout` (line 215), update to:
+
+```rust
+    #[tokio::test]
+    async fn test_kas_network_timeout() {
+        let kas_url = "https://192.0.2.1:9999";
+        let cfg = OpentdfConfiguration::for_kas_connect(kas_url);
+        let client = KasClient::new(&cfg, "token").unwrap();
+
+        let manifest = create_test_manifest_with_policy(kas_url.to_string());
+        // ... rest unchanged
+```
+
+- [ ] **Step 6: Update `tests/kas_integration.rs` constructor calls**
+
+Open `tests/kas_integration.rs`. At each `KasClient::new(&kas_url, &oauth_token)` (lines 66 and 119), construct via:
+
+```rust
+        let cfg = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, &oauth_token)
+            .expect("Failed to create KAS client");
+```
+
+If `KasClient` is imported via `use opentdf::kas::KasClient`, add `use opentdf::kas_discovery::OpentdfConfiguration` and use the shorter path.
+
+- [ ] **Step 7: Update `src/tdf.rs` doc examples**
+
+In `src/tdf.rs` at lines 90 and 113, replace each `KasClient::new("https://kas.example.com", "token")?;` with:
+
+```rust
+    /// let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+    ///     "https://kas.example.com",
+    /// );
+    /// let kas_client = KasClient::new(&config, "token")?;
+```
+
+- [ ] **Step 8: Update `src/archive.rs` doc examples**
+
+In `src/archive.rs` at lines 50 and 309, apply the same replacement as Step 7.
+
+- [ ] **Step 9: Update `examples/kas_decrypt.rs`**
+
+In `examples/kas_decrypt.rs` around line 43:
+
+```rust
+    let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(&kas_url);
+    let kas_client = match KasClient::new(&config, &kas_token) {
+```
+
+- [ ] **Step 10: Update `examples/create_tdf_platform.rs` constructor**
+
+In `examples/create_tdf_platform.rs`, locate the `KasClient::new(...)` call (if present — grep first). If the example uses `KasClient` directly, wrap the base URL via `OpentdfConfiguration::for_kas_connect`. Public-key fetching is updated in Task 10.
+
+```bash
+grep -n "KasClient::new\|fetch_kas_public_key" examples/create_tdf_platform.rs
+```
+
+If `KasClient::new(...)` appears, replace as in Step 9. Skip Public-key changes for now.
+
+- [ ] **Step 11: Update `examples/kas_sanity_test.rs`**
+
+Open `examples/kas_sanity_test.rs`. The current line 13 hardcodes `"https://100.arkavo.net/kas/v2/rewrap"`. Change to:
+
+```rust
+    let kas_base_url = "https://100.arkavo.net";
+    let kas_url = "https://100.arkavo.net/kas.AccessService/Rewrap";  // for display only
+```
+
+If the example builds a `KasClient`, construct via `OpentdfConfiguration::for_kas_connect(kas_base_url)`.
+
+- [ ] **Step 12: Update `examples/jwt_helper.rs` doc string**
+
+In `examples/jwt_helper.rs` line 149, change:
+
+```rust
+    println!("let kas_client = KasClient::new(kas_url, oauth_token)?;");
+```
+
+to:
+
+```rust
+    println!("let config = OpentdfConfiguration::for_kas_connect(kas_url);");
+    println!("let kas_client = KasClient::new(&config, oauth_token)?;");
+```
+
+- [ ] **Step 13: Build and test**
+
+Run:
+```bash
+cargo build --all-features
+cargo test --all-features
+cargo build --examples --all-features
+```
+Expected: clean build, all tests pass, all examples compile.
+
+- [ ] **Step 14: Clippy**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+Expected: clean — no warnings.
+
+- [ ] **Step 15: Format**
+
+Run: `cargo fmt --all`
+Expected: no diff (or only whitespace).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+feat(kas)!: KasClient::new takes &OpentdfConfiguration (#85)
+
+Breaking change. Pre-resolved configuration is now required at construction
+time; discovery is a separate async free function (fetch_well_known) so
+KasClient::new stays synchronous.
+
+Migration:
+  // before
+  let client = KasClient::new("https://kas.example.com", token)?;
+
+  // after
+  let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+  let client = KasClient::new(&cfg, token)?;
+
+Or, with discovery:
+  let cfg = fetch_well_known("https://platform.example.com", &http).await?;
+  let client = KasClient::new(&cfg, token)?;
+
+Updated all in-repo callers (tests, examples, doc examples) in this commit.
+EOF
+)"
+```
+
+---
+
+## Task 9: Connect siblings for KAS public-key fetch
+
+**Files:**
+- Modify: `src/kas_key.rs`
+
+- [ ] **Step 1: Add a failing test for the Connect variant**
+
+Append to the existing `#[cfg(test)] mod tests` block in `src/kas_key.rs`:
+
+```rust
+    #[cfg(feature = "kas-client")]
+    #[tokio::test]
+    async fn test_fetch_kas_public_key_connect_against_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/kas.AccessService/PublicKey")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"publicKey":"-----BEGIN PUBLIC KEY-----\ntestkey\n-----END PUBLIC KEY-----\n","kid":"r1"}"#)
+            .create_async()
+            .await;
+
+        let url = format!("{}/kas.AccessService/PublicKey", server.url());
+        let http = reqwest::Client::new();
+        let resp = fetch_kas_public_key_connect(&url, &http).await.unwrap();
+        assert!(resp.public_key.starts_with("-----BEGIN PUBLIC KEY-----"));
+        assert_eq!(resp.kid, "r1");
+    }
+
+    #[cfg(feature = "kas-client")]
+    #[tokio::test]
+    async fn test_fetch_kas_ec_public_key_connect_against_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/kas.AccessService/PublicKey")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"publicKey":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/shJbT/RbVUkgV+/5m+KPblr5ZXH\nHU+2K5VytEsGQJJ0fxiksZXDC7twCPAXZgE3LOvORGqbQriKe/nM4iqIuA==\n-----END PUBLIC KEY-----\n","kid":"ec:secp256r1"}"#)
+            .create_async()
+            .await;
+
+        let url = format!("{}/kas.AccessService/PublicKey", server.url());
+        let http = reqwest::Client::new();
+        let resp = fetch_kas_ec_public_key_connect(&url, &http).await.unwrap();
+        assert_eq!(resp.kid, "ec:secp256r1");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --features kas-client --lib kas_key::tests::test_fetch_kas_public_key_connect`
+Expected: FAIL — functions undefined.
+
+- [ ] **Step 3: Implement `fetch_kas_public_key_connect`**
+
+In `src/kas_key.rs`, add after the existing `fetch_kas_public_key` function:
+
+```rust
+/// Fetch the KAS public key via ConnectRPC.
+///
+/// Unlike `fetch_kas_public_key`, this expects a pre-resolved URL (typically
+/// from `KasEndpoints::public_key_url`) and POSTs an empty JSON body — the
+/// Connect protocol requires a request body even for empty message types.
+#[cfg(feature = "kas-client")]
+pub async fn fetch_kas_public_key_connect(
+    public_key_url: &str,
+    http_client: &Client,
+) -> Result<KasPublicKeyResponse, KasKeyError> {
+    let response = http_client
+        .post(public_key_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        return Err(KasKeyError::HttpError(format!(
+            "POST {} -> HTTP {}: {}",
+            public_key_url, status, error_body
+        )));
+    }
+
+    let key_response: KasPublicKeyResponse = response.json().await?;
+    Ok(key_response)
+}
+```
+
+- [ ] **Step 4: Implement `fetch_kas_ec_public_key_connect`**
+
+In `src/kas_key.rs`, add after the existing `fetch_kas_ec_public_key` function:
+
+```rust
+/// Fetch the KAS EC public key via ConnectRPC.
+///
+/// Unlike `fetch_kas_ec_public_key`, this expects a pre-resolved URL.
+#[cfg(feature = "kas-client")]
+pub async fn fetch_kas_ec_public_key_connect(
+    public_key_url: &str,
+    http_client: &Client,
+) -> Result<KasEcPublicKeyResponse, KasKeyError> {
+    let response = http_client
+        .post(public_key_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        return Err(KasKeyError::HttpError(format!(
+            "POST {} -> HTTP {}: {}",
+            public_key_url, status, error_body
+        )));
+    }
+
+    let key_response: KasEcPublicKeyResponse = response.json().await?;
+    validate_ec_public_key_pem(&key_response.public_key)?;
+    Ok(key_response)
+}
+```
+
+- [ ] **Step 5: Deprecate the REST variants**
+
+In `src/kas_key.rs`, add a deprecation attribute to both `fetch_kas_public_key` and `fetch_kas_ec_public_key`. Find the function signature lines (73 and 157), and immediately above each `#[cfg(feature = "kas-client")]` line, add:
+
+```rust
+#[deprecated(
+    since = "0.13.0",
+    note = "Legacy /kas/v2/* REST endpoint. Use fetch_kas_public_key_connect with a URL resolved from OpentdfConfiguration or fetch_well_known()."
+)]
+```
+
+- [ ] **Step 6: Run tests to verify the new tests pass**
+
+Run: `cargo test --features kas-client --lib kas_key::tests::test_fetch_kas_public_key_connect kas_key::tests::test_fetch_kas_ec_public_key_connect`
+Expected: PASS.
+
+- [ ] **Step 7: Build with deprecation warnings allowed**
+
+Run: `cargo build --all-features`
+Expected: build succeeds. Deprecation warnings will appear for the REST functions — they're informational, not errors.
+
+- [ ] **Step 8: Update `examples/create_tdf_platform.rs` to use Connect**
+
+In `examples/create_tdf_platform.rs` at line 50:
+
+```rust
+    let kas_pk_url = format!("{}/kas.AccessService/PublicKey", kas_url.trim_end_matches('/'));
+    let kas_key_response =
+        opentdf::kas_key::fetch_kas_public_key_connect(&kas_pk_url, &http_client).await?;
+```
+
+- [ ] **Step 9: Suppress deprecation warnings in remaining callers**
+
+Run: `cargo build --all-features 2>&1 | grep "deprecated" | head -20`
+
+For each remaining caller that uses `fetch_kas_public_key` or `fetch_kas_ec_public_key`, prefix the call with `#[allow(deprecated)]` on the function or block, OR migrate to the Connect variant. If a caller is in `examples/mock_kas_server.rs` or another example that intentionally exercises the legacy path, add the `#[allow(deprecated)]` attribute.
+
+- [ ] **Step 10: Clean build with warnings as errors**
+
+Run: `RUSTFLAGS="-D warnings" cargo build --all-features`
+Expected: clean build — any remaining deprecation calls must be `#[allow(deprecated)]`'d or migrated.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/kas_key.rs examples/create_tdf_platform.rs
+# add any other files touched in step 9
+git commit -m "feat(kas): Connect siblings for public-key fetch, deprecate REST (#85)"
+```
+
+---
+
+## Task 10: Add Connect routes to `examples/mock_kas_server.rs`
+
+**Files:**
+- Modify: `examples/mock_kas_server.rs`
+
+- [ ] **Step 1: Add Connect-route handlers**
+
+In `examples/mock_kas_server.rs` at the route registration (around line 708):
+
+```rust
+        .route("/kas/v2/kas_public_key", get(get_public_key_with_algorithm))
+        .route("/kas/v2/rewrap", post(rewrap))
+        .route("/kas.AccessService/PublicKey", post(get_public_key_connect))
+        .route("/kas.AccessService/Rewrap", post(rewrap))
+```
+
+The legacy REST routes stay (multi-profile mock). Both paths can share the `rewrap` handler — same request shape.
+
+- [ ] **Step 2: Add a Connect-shape public-key handler**
+
+The existing `get_public_key_with_algorithm` reads the algorithm from a query parameter (GET). For Connect, the algorithm comes from the JSON body. Add a sibling handler:
+
+```rust
+#[derive(serde::Deserialize, Default)]
+struct PublicKeyConnectRequest {
+    #[serde(default)]
+    algorithm: Option<String>,
+}
+
+async fn get_public_key_connect(
+    State(state): State<AppState>,
+    body: Option<Json<PublicKeyConnectRequest>>,
+) -> impl IntoResponse {
+    let algorithm = body
+        .and_then(|Json(req)| req.algorithm)
+        .unwrap_or_else(|| "rsa:2048".to_string());
+
+    // Delegate to the existing algorithm-aware response, but return
+    // camelCase publicKey for Connect protojson compatibility.
+    let (pem, kid) = state.public_keys_for(&algorithm);
+
+    Json(serde_json::json!({
+        "publicKey": pem,
+        "kid": kid,
+    }))
+}
+```
+
+Note: if `public_keys_for` is not an existing method, replace its body with the same lookup logic that `get_public_key_with_algorithm` uses, returning a `(String, String)` tuple of `(pem, kid)`. Read `get_public_key_with_algorithm` first to crib its implementation.
+
+- [ ] **Step 3: Update the startup banner**
+
+In `examples/mock_kas_server.rs`, around lines 701-702 where the server prints its routes, add:
+
+```rust
+    println!("  POST /kas.AccessService/PublicKey - Get KAS public key (ConnectRPC)");
+    println!("  POST /kas.AccessService/Rewrap    - Rewrap key (ConnectRPC)");
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+In one terminal:
+```bash
+cargo run --example mock_kas_server --features kas-client,cbor
+```
+
+In another:
+```bash
+curl -sX POST http://localhost:8080/kas.AccessService/PublicKey \
+  -H 'content-type: application/json' -d '{}'
+```
+
+Expected: JSON response with `publicKey` (camelCase) and `kid` fields.
+
+- [ ] **Step 5: Stop the mock server (Ctrl+C in terminal 1)**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/mock_kas_server.rs
+git commit -m "feat(mock-kas): add ConnectRPC routes alongside legacy REST (#85)"
+```
+
+---
+
+## Task 11: Live integration tests against `platform.arkavo.net`
+
+**Files:**
+- Modify: `tests/platform_integration.rs`
+
+- [ ] **Step 1: Append three new ignored integration tests**
+
+At the end of `tests/platform_integration.rs`, append:
+
+```rust
+// ---------------------------------------------------------------------------
+// ConnectRPC migration verification (#85)
+//
+// These tests run against the real Arkavo platform and document the milestone
+// state of the Connect transport. They are #[ignore]d by default; opt in with:
+//
+//   cargo test --test platform_integration --all-features -- --ignored connect
+//
+// or, if KAS_INTEGRATION_TESTS=1 is set, the user can run them by name.
+// ---------------------------------------------------------------------------
+
+const ARKAVO_PLATFORM: &str = "https://platform.arkavo.net";
+
+#[tokio::test]
+#[ignore]
+async fn connect_well_known_endpoint_returns_kas_config() -> Result<(), Box<dyn Error>> {
+    use opentdf::kas_discovery::fetch_well_known;
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    let kas = cfg.kas.expect("kas block should be present");
+    assert!(
+        kas.connect_rewrap_url.is_some(),
+        "platform should advertise connect_rewrap_url"
+    );
+    assert!(
+        kas.connect_public_key_url.is_some(),
+        "platform should advertise connect_public_key_url"
+    );
+    assert!(
+        kas.rewrap_url.is_some(),
+        "platform also exposes legacy REST rewrap_url (transitional)"
+    );
+    println!("✓ well-known reports both Connect and REST URLs");
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn connect_public_key_returns_pem() -> Result<(), Box<dyn Error>> {
+    use opentdf::kas_discovery::{KasEndpoints, fetch_well_known};
+    use opentdf::kas_key::fetch_kas_public_key_connect;
+
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    let endpoints = KasEndpoints::from_config(&cfg)?;
+    let resp = fetch_kas_public_key_connect(&endpoints.public_key_url, &http).await?;
+    assert!(
+        resp.public_key.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "expected PEM, got: {}",
+        resp.public_key
+    );
+    assert!(!resp.kid.is_empty(), "kid should be populated");
+    println!("✓ Connect PublicKey returned kid={} ({} bytes PEM)", resp.kid, resp.public_key.len());
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn connect_rewrap_fails_with_fake_bearer_returns_401() -> Result<(), Box<dyn Error>> {
+    use opentdf::TdfManifest;
+    use opentdf::kas::KasClient;
+    use opentdf::kas_discovery::fetch_well_known;
+    use opentdf_protocol::KasError;
+
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    // Pass a syntactically-plausible bearer that the platform will reject.
+    let client = KasClient::new(&cfg, "eyJhbGciOiJub25lIn0.e30.")?;
+
+    let manifest = TdfManifest::new("0.payload".to_string(), ARKAVO_PLATFORM.to_string());
+    let result = client.rewrap_standard_tdf(&manifest).await;
+
+    let err = result.err().expect("rewrap should fail without valid auth");
+    match &err {
+        KasError::AuthenticationFailed { reason } => {
+            // Connect 'unauthenticated' code should surface in the reason string
+            // when the platform returns a Connect error envelope.
+            println!("✓ Connect rewrap returned AuthenticationFailed: {reason}");
+        }
+        KasError::AccessDenied { reason, .. } => {
+            // Some Connect implementations may return permission_denied (403)
+            // when the request is malformed.
+            println!("✓ Connect rewrap returned AccessDenied: {reason}");
+        }
+        KasError::HttpError { status, message } => {
+            // Acceptable: a generic HTTP error proves we hit Connect, not REST.
+            println!("✓ Connect rewrap returned HTTP {status}: {message}");
+            assert!(
+                *status >= 400 && *status < 600,
+                "expected 4xx/5xx, got {status}"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Build the test binary**
+
+Run: `cargo build --tests --all-features`
+Expected: clean build.
+
+- [ ] **Step 3: Run the new integration tests against the live platform**
+
+Run:
+```bash
+cargo test --test platform_integration --all-features -- --ignored connect_well_known
+cargo test --test platform_integration --all-features -- --ignored connect_public_key
+cargo test --test platform_integration --all-features -- --ignored connect_rewrap_fails
+```
+
+Expected outputs:
+- `connect_well_known_endpoint_returns_kas_config`: PASS — well-known fetched, kas block has both URL pairs.
+- `connect_public_key_returns_pem`: PASS — Connect PublicKey returns valid PEM.
+- `connect_rewrap_fails_with_fake_bearer_returns_401`: PASS — Connect Rewrap returns 401 with `unauthenticated` (or otherwise a 4xx/5xx documenting the next blocker).
+
+If the platform is unreachable, skip and note for the PR description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/platform_integration.rs
+git commit -m "test(kas): live Connect/well-known integration against platform.arkavo.net (#85)"
+```
+
+---
+
+## Task 12: Version bump, CHANGELOG, README, final checks
+
+**Files:**
+- Modify: `Cargo.toml` (root)
+- Modify: `crates/crypto/Cargo.toml`
+- Modify: `crates/wasm/Cargo.toml`
+- Create or modify: `CHANGELOG.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Bump workspace version**
+
+In `Cargo.toml` (root), find the `[workspace.package]` block and change:
+
+```toml
+[workspace.package]
+version = "0.12.0"
+```
+
+to:
+
+```toml
+[workspace.package]
+version = "0.13.0"
+```
+
+- [ ] **Step 2: Bump path-dep pins**
+
+In `Cargo.toml` (root) lines 18-19:
+```toml
+opentdf-protocol = { path = "crates/protocol", version = "0.13.0" }
+opentdf-crypto = { path = "crates/crypto", version = "0.13.0", default-features = false }
+```
+
+In `crates/crypto/Cargo.toml`, find any pinned version reference to `opentdf-protocol` and bump to `0.13.0`.
+
+In `crates/wasm/Cargo.toml`, bump any pinned references to `opentdf`, `opentdf-protocol`, or `opentdf-crypto` to `0.13.0`.
+
+- [ ] **Step 3: Update or create CHANGELOG.md**
+
+```bash
+test -f CHANGELOG.md || echo "# Changelog" > CHANGELOG.md
+```
+
+Insert at the top, immediately after the title:
+
+```markdown
+## [0.13.0] — 2026-05-28
+
+### Breaking changes
+
+- `KasClient::new` now takes `&OpentdfConfiguration` instead of a base URL string. Migrate via:
+  ```rust
+  // before
+  let client = KasClient::new("https://kas.example.com", token)?;
+
+  // after
+  let cfg = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+      "https://kas.example.com",
+  );
+  let client = KasClient::new(&cfg, token)?;
+  ```
+  For discovery-driven setups, use `fetch_well_known(platform_url, &http).await?` to obtain the config.
+
+### Added
+
+- `opentdf::kas_discovery` module:
+  - `OpentdfConfiguration` deserialization of `/.well-known/opentdf-configuration`
+  - `KasEndpoints::from_config` with Connect-preferred / REST-fallback URL resolution
+  - `OpentdfConfiguration::for_kas_connect` / `for_kas_legacy_rest` direct builders
+  - `fetch_well_known` async discovery
+  - `parse_connect_error` Connect error envelope parser
+- `opentdf::kas_key::fetch_kas_public_key_connect` and `fetch_kas_ec_public_key_connect` for ConnectRPC public-key retrieval
+- Live ConnectRPC integration tests against `platform.arkavo.net` in `tests/platform_integration.rs` (`#[ignore]`d by default)
+- ConnectRPC route handlers in `examples/mock_kas_server.rs`
+
+### Changed
+
+- KAS rewrap now POSTs to `/kas.AccessService/Rewrap` (ConnectRPC) instead of `/kas/v2/rewrap` (legacy REST)
+- Connect error envelope (`{code, message}`) parsed into `KasError` reason strings
+
+### Deprecated
+
+- `opentdf::kas_key::fetch_kas_public_key` — use `fetch_kas_public_key_connect`
+- `opentdf::kas_key::fetch_kas_ec_public_key` — use `fetch_kas_ec_public_key_connect`
+
+### Notes
+
+- The `oauth_token` parameter of `KasClient::new` is an opaque passthrough. Pass a JWT or a base64url-encoded CWT; the server decides how to validate.
+- Closes [#85](https://github.com/arkavo-org/opentdf-rs/issues/85).
+```
+
+- [ ] **Step 4: Update README.md**
+
+In `README.md`, find any usage example that constructs a `KasClient`. Replace with the new shape:
+
+```rust
+use opentdf::kas::KasClient;
+use opentdf::kas_discovery::{fetch_well_known, OpentdfConfiguration};
+
+// Discovery (recommended):
+let http = reqwest::Client::new();
+let cfg = fetch_well_known("https://platform.arkavo.net", &http).await?;
+let kas = KasClient::new(&cfg, oauth_token)?;
+
+// Direct (skip discovery):
+let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+let kas = KasClient::new(&cfg, oauth_token)?;
+```
+
+- [ ] **Step 5: Pre-commit checklist**
+
+Run each of these and confirm clean output:
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+RUSTFLAGS="-D warnings" cargo build --all-features
+```
+
+If WASM code changed in this PR (it shouldn't have — out of scope), additionally:
+
+```bash
+cd crates/wasm
+wasm-pack build --target web --out-dir pkg-web
+wasm-pack build --target bundler --out-dir pkg
+wasm-pack build --target nodejs --out-dir pkg-node
+cd ../..
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml crates/crypto/Cargo.toml crates/wasm/Cargo.toml CHANGELOG.md README.md
+git commit -m "chore: bump to 0.13.0, CHANGELOG, README for ConnectRPC migration (#85)"
+```
+
+- [ ] **Step 7: Verify full history**
+
+Run: `git log --oneline origin/main..HEAD`
+Expected: a clean sequence of the task commits, each focused, each compilable.
+
+- [ ] **Step 8: Push and open PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "feat(kas): ConnectRPC migration with well-known discovery (#85)" --body "$(cat <<'EOF'
+## Summary
+- Switches the native KAS client transport from `/kas/v2/*` REST to `/kas.AccessService/*` ConnectRPC.
+- Adds `src/kas_discovery.rs` with well-known fetch and Connect-preferred URL resolution.
+- `KasClient::new` now takes a pre-resolved `&OpentdfConfiguration` (breaking; 0.13.0 minor bump).
+- Live tests against `platform.arkavo.net` validate end-to-end Connect plumbing. CWT-as-bearer support is server-side; client passes the bearer opaquely.
+
+Closes #85.
+
+## Test plan
+- [ ] `cargo test --all-features` — green
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
+- [ ] `cargo test --test platform_integration --all-features -- --ignored connect` — three Connect tests pass against platform.arkavo.net
+- [ ] `cargo run --example mock_kas_server` + curl Connect endpoint manually
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — walked each section of the design doc:
+
+| Spec section | Task(s) |
+|---|---|
+| Discovery module (`OpentdfConfiguration`, `KasConfig`, `IdpConfig`, `KasEndpoints`, `KasTransport`, `fetch_well_known`, builders) | 1–6 |
+| `KasClient::new(&OpentdfConfiguration, token)` sync construction | 8 |
+| Connect URL switch in `send_rewrap_request` | 7 |
+| Connect error envelope parsing + `KasError` mapping | 5, 7 |
+| `fetch_kas_public_key_connect` / `fetch_kas_ec_public_key_connect`, deprecate REST | 9 |
+| CWT bearer = opaque passthrough (no client-side change) | 8 (doc comments) |
+| Mock-server tests on `/kas.AccessService/Rewrap` + Connect 401 envelope test | 7 |
+| Mock-server tests on `/kas.AccessService/PublicKey` | 9 |
+| Live integration tests against `platform.arkavo.net` | 11 |
+| `examples/mock_kas_server.rs` ConnectRPC routes | 10 |
+| Examples + tests migrated to new constructor | 8 |
+| Version bump 0.12.0 → 0.13.0, CHANGELOG | 12 |
+| Pre-commit checklist (fmt, clippy, test, warnings-as-errors build) | 12 |
+
+No gaps.
+
+**Placeholder scan** — no TBDs, no "add error handling," no "similar to Task N." Every code-bearing step has actual code. The one soft spot is Task 8 Step 10 (`examples/create_tdf_platform.rs` constructor migration), where the exact line depends on what `grep` finds — the step has a grep command and an "if present" pattern, which is necessary because the file's call site may vary by branch; this is targeted rather than vague.
+
+**Type consistency** — `OpentdfConfiguration`, `KasConfig`, `KasEndpoints`, `KasTransport`, `ConnectError`, `fetch_well_known`, `parse_connect_error`, `for_kas_connect`, `for_kas_legacy_rest`, `fetch_kas_public_key_connect`, `fetch_kas_ec_public_key_connect`, `KasClient::new` — names match between definitions, callers, and the `kas_discovery::OpentdfConfiguration` qualified path in test code. No drift.
+
+**One scope note** — `examples/cross_sdk_test.rs` and `examples/xtest_cli.rs` use the builder pattern (`.kas_url(...)`) on a higher-level helper and may not call `KasClient::new` directly. Task 8 Step 5–11 covers the direct callers (kas_decrypt, create_tdf_platform, kas_sanity_test, jwt_helper); if `cargo build --examples` in Step 13 fails on cross_sdk_test or xtest_cli, fix in-place and amend that commit before continuing.

--- a/docs/superpowers/specs/2026-05-28-connectrpc-kas-migration-design.md
+++ b/docs/superpowers/specs/2026-05-28-connectrpc-kas-migration-design.md
@@ -1,0 +1,293 @@
+# Design: Migrate KAS client to ConnectRPC with well-known discovery
+
+**Status:** Draft for review
+**Date:** 2026-05-28
+**Tracking issue:** [#85](https://github.com/arkavo-org/opentdf-rs/issues/85)
+**Related:** [#46](https://github.com/arkavo-org/opentdf-rs/issues/46) (OIDC auth), [#43](https://github.com/arkavo-org/opentdf-rs/issues/43) (WASM ZTDF decrypt)
+
+## Motivation
+
+The opentdf-platform Go server serves KAS over ConnectRPC at `/kas.AccessService/{Rewrap,PublicKey}`. Issue #85 states the platform "no longer ships" the legacy `/kas/v2/*` REST gateway, though `platform.arkavo.net` currently exposes both surfaces. The Rust client (`src/kas.rs`, `src/kas_key.rs`) is REST-only today and will fail against any deployment that drops the gateway.
+
+The platform's `/.well-known/opentdf-configuration` endpoint advertises both transports side by side:
+
+```json
+"kas": {
+  "algorithms": ["ec:secp256r1", "rsa:2048"],
+  "connect_public_key_url": "https://platform.arkavo.net/kas.AccessService/PublicKey",
+  "connect_rewrap_url":     "https://platform.arkavo.net/kas.AccessService/Rewrap",
+  "public_key_url":         "https://platform.arkavo.net/kas/v2/kas_public_key",
+  "rewrap_url":             "https://platform.arkavo.net/kas/v2/rewrap",
+  "uri":                    "https://platform.arkavo.net"
+}
+```
+
+This lets the client prefer Connect when advertised and fall back to REST otherwise — backward-compat answered by the server, not by client feature flags.
+
+## Scope (first cut)
+
+- **In:** Native (`src/kas.rs`, `src/kas_key.rs`) ConnectRPC transport + well-known discovery + CWT-as-bearer support (server-side validation will fail until platform CWT lands; acceptable).
+- **Out:** WASM mirror (`crates/wasm/src/kas.rs`), client-side CWT signing/verification, OIDC auth provider, removal of legacy REST mock routes.
+
+The CWT-bearer aspect of the work is intentionally minimal on the client side: `oauth_token` is an opaque passthrough string. The caller decides whether they're providing a JWT or a base64url-encoded CWT. The Rust client puts whatever they pass after `Authorization: Bearer ` and lets the server validate. Expected end state on `platform.arkavo.net`: rewrap returns HTTP 401 with a Connect `unauthenticated` error envelope. That confirms transport plumbing is correct.
+
+## Non-goals
+
+- Switching to Connect's binary `application/proto` codec. JSON envelope wins on debuggability and zero new dependencies; size savings (~25% on response wrapped-key bytes only) are sub-MTU on a latency-bound path.
+- Code-gen via `prost`/`tonic`/`connect-codegen`. Two unary RPCs don't justify the dep weight.
+- Caching the well-known response between `KasClient` instances. Callers cache `OpentdfConfiguration` themselves if they want; the discovery function is one HTTP GET and the result is plain data.
+
+## Architecture
+
+New module: `src/kas_discovery.rs`. Owns:
+
+- `OpentdfConfiguration` — deserializes the well-known JSON shape.
+- `KasConfig`, `IdpConfig` — sub-structs (`IdpConfig` deserialized but unused; reserved for #46).
+- `KasEndpoints` — resolved URLs after applying the Connect-preferred / REST-fallback rule, plus a `KasTransport` enum for logging.
+- `fetch_well_known(platform_url, &http_client)` — async, one GET request.
+- `OpentdfConfiguration::for_kas_connect(base_url)` — synthesize a config from a KAS base URL using Connect paths.
+- `OpentdfConfiguration::for_kas_legacy_rest(base_url)` — escape hatch for pre-Connect deployments.
+
+`src/kas.rs` changes:
+
+- `KasClient` struct: new `endpoints: KasEndpoints` field replaces internal use of `base_url` for URL construction. `base_url` retained for backwards-compat field access.
+- `KasClient::new(config: &OpentdfConfiguration, oauth_token)` — synchronous; reads URLs from the resolved endpoints, applies existing HTTPS/SSRF validation to those URLs, generates RSA-2048 signing key as before. **Breaking change** from current `new(base_url, oauth_token)`.
+- `send_rewrap_request` — POSTs to `endpoints.rewrap_url` instead of `format!("{}/kas/v2/rewrap", base_url)`. Adds Connect error envelope parsing.
+
+`src/kas_key.rs` changes:
+
+- New `fetch_kas_public_key_connect(public_key_url, &http_client)` — POSTs to a pre-resolved URL with empty JSON body `{}`. No path mangling (the URL is already resolved by discovery or builder).
+- New `fetch_kas_ec_public_key_connect` mirror.
+- Existing `fetch_kas_public_key` / `fetch_kas_ec_public_key` marked `#[deprecated]` with a hint to use the Connect variants.
+
+## API surface
+
+```rust
+// src/kas_discovery.rs
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpentdfConfiguration {
+    pub kas: Option<KasConfig>,
+    pub idp: Option<IdpConfig>,
+    pub platform_issuer: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KasConfig {
+    pub uri: String,
+    pub algorithms: Vec<String>,
+    pub public_key_url: Option<String>,
+    pub rewrap_url: Option<String>,
+    pub connect_public_key_url: Option<String>,
+    pub connect_rewrap_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdpConfig {
+    pub issuer: String,
+    pub jwks_uri: Option<String>,
+    pub cose_keys_uri: Option<String>,
+    pub token_endpoint: Option<String>,
+    pub authorization_endpoint: Option<String>,
+    pub userinfo_endpoint: Option<String>,
+    pub access_token_format: Option<String>,
+    pub id_token_signing_alg_values_supported: Option<Vec<String>>,
+    pub response_types_supported: Option<Vec<String>>,
+    pub subject_types_supported: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KasTransport { Connect, LegacyRest }
+
+#[derive(Debug, Clone)]
+pub struct KasEndpoints {
+    pub rewrap_url: String,
+    pub public_key_url: String,
+    pub transport: KasTransport,
+}
+
+impl OpentdfConfiguration {
+    pub fn for_kas_connect(base_url: impl Into<String>) -> Self;
+    pub fn for_kas_legacy_rest(base_url: impl Into<String>) -> Self;
+}
+
+impl KasEndpoints {
+    pub fn from_config(cfg: &OpentdfConfiguration) -> Result<Self, KasError>;
+}
+
+pub async fn fetch_well_known(
+    platform_url: &str,
+    http_client: &reqwest::Client,
+) -> Result<OpentdfConfiguration, KasError>;
+```
+
+```rust
+// src/kas.rs
+
+impl KasClient {
+    pub fn new(
+        config: &OpentdfConfiguration,
+        oauth_token: impl Into<String>,
+    ) -> Result<Self, KasError>;
+}
+```
+
+```rust
+// src/kas_key.rs
+
+pub async fn fetch_kas_public_key_connect(
+    public_key_url: &str,
+    http_client: &reqwest::Client,
+) -> Result<KasPublicKeyResponse, KasKeyError>;
+
+pub async fn fetch_kas_ec_public_key_connect(
+    public_key_url: &str,
+    http_client: &reqwest::Client,
+) -> Result<KasEcPublicKeyResponse, KasKeyError>;
+```
+
+## Caller patterns
+
+```rust
+// Production: discover, then construct
+let http = reqwest::Client::new();
+let cfg = fetch_well_known("https://platform.arkavo.net", &http).await?;
+let kas = KasClient::new(&cfg, bearer_token)?;
+
+// Connect, no discovery
+let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+let kas = KasClient::new(&cfg, bearer_token)?;
+
+// REST escape hatch
+let cfg = OpentdfConfiguration::for_kas_legacy_rest("https://kas.example.com");
+let kas = KasClient::new(&cfg, bearer_token)?;
+```
+
+## Data flow
+
+### Construction (discovery path)
+1. Caller constructs `reqwest::Client`.
+2. `fetch_well_known(platform_url, &http)` → GET `/.well-known/opentdf-configuration` → `OpentdfConfiguration`.
+3. `KasClient::new(&cfg, token)`:
+   - `KasEndpoints::from_config(&cfg)` resolves URLs: prefer `connect_*_url`, fall back to `*_url`. Error if both absent.
+   - Apply existing HTTPS / SSRF / scheme validation to resolved URLs.
+   - Generate ephemeral RSA-2048 signing key (unchanged).
+
+### Rewrap (Standard TDF)
+1. Generate ephemeral RSA-2048 keypair (unchanged).
+2. Build `UnsignedRewrapRequest` from manifest (unchanged).
+3. Sign with internal signing key → `signed_request_token` (RS256 JWT, unchanged). **This is the rewrap-request signature, not the access token.**
+4. POST `endpoints.rewrap_url`:
+   - `content-type: application/json`
+   - `authorization: Bearer {oauth_token}` (opaque passthrough — JWT or base64url-CBOR CWT)
+   - body: `{"signed_request_token": "..."}` (Connect proto JSON, unchanged shape)
+5. Handle response:
+   - 401 → `KasError::AuthenticationFailed { reason }` (reason includes Connect `code: message` when parseable)
+   - 403 → `KasError::AccessDenied`
+   - Other 4xx/5xx → `KasError::HttpError`
+   - 200 with empty `responses` and parseable Connect error → `KasError::HttpError` (defensive)
+   - 200 → parse `RewrapResponse` (unchanged shape).
+6. Extract wrapped key, unwrap via RSA-OAEP (unchanged).
+
+### PublicKey fetch
+1. POST `endpoints.public_key_url`:
+   - `content-type: application/json`
+   - body: `{}` (Connect requires a JSON body even for empty request types)
+2. 200 → parse `KasPublicKeyResponse` (struct already uses `#[serde(rename = "publicKey")]`, matches Connect's protojson camelCase).
+3. Non-200 → `KasKeyError::HttpError` with parsed Connect detail when available.
+
+## Bearer encoding rationale
+
+`Authorization: Bearer <base64url(CWT_bytes)>`:
+
+- **Standards-conformant:** RFC 6750 requires bearer tokens to be visible ASCII, so raw CBOR cannot go directly in the header. Base64url is the same encoding JWT uses (compact serialization) and matches the platform's own `examples/pep_check.rs` convention (commit `85b8b05`), which decodes access tokens as base64url with optional CWT tag #61 strip.
+- **Performant:** Base64url is byte-shifting (sub-microsecond); the ~33% size inflation on a ~300-byte CWT puts the header well under any reasonable limit and dwarfs nothing in the TLS-handshake-dominated request lifecycle.
+- **JWT/CWT distinguishable server-side without protocol changes:** CBOR bytes have distinct leading bytes from `eyJ...` (JWT). The server inspects.
+
+## Error mapping
+
+Connect unary-JSON returns errors with shape:
+```json
+{ "code": "unauthenticated", "message": "missing bearer token" }
+```
+
+Implementation: small helper struct + parser. Map Connect-status codes to existing `KasError` variants via the HTTP status code (Connect spec defines the mapping — `unauthenticated` → 401, `permission_denied` → 403, etc.). Surface the Connect `code: message` as the `reason` field of the resulting `KasError` variant. **No new `KasError` variants required.**
+
+## Testing strategy
+
+### Unit tests
+
+- `kas_discovery::tests`:
+  - `from_config_picks_connect_when_present`
+  - `from_config_falls_back_to_rest_when_connect_absent`
+  - `from_config_errors_when_neither_present`
+  - `for_kas_connect_constructs_expected_urls` (`https://kas.example.com` → `/kas.AccessService/{Rewrap,PublicKey}`)
+  - `for_kas_legacy_rest_constructs_expected_urls`
+  - `parse_connect_error_with_valid_body` / `parse_connect_error_with_garbage`
+
+- `kas_discovery::tests` for `fetch_well_known` (mockito):
+  - Happy path returns platform's JSON shape.
+  - 404 → `KasError::HttpError`.
+  - Garbled JSON → parse error.
+
+- `kas::tests::url_validation_tests`: existing SSRF / HTTPS coverage adapted to new constructor signature.
+
+### Mock-server tests (`tests/kas_mock.rs`)
+
+- Update all six mock routes from `/kas/v2/rewrap` to `/kas.AccessService/Rewrap`.
+- New test for Connect 401 envelope: mock returns 401 with `{"code":"unauthenticated","message":"bad token"}`, assert `KasError::AuthenticationFailed { reason }` contains `"unauthenticated"`.
+- New test for the Connect public-key fetch via mock POST to `/kas.AccessService/PublicKey`.
+
+### Live integration tests (`tests/platform_integration.rs`, `#[ignore]`)
+
+Gated by `KAS_INTEGRATION_TESTS=1`:
+
+- `well_known_endpoint_returns_kas_config` — fetch against `platform.arkavo.net`, assert kas block has both Connect and REST URLs.
+- `connect_public_key_returns_pem` — fetch via Connect transport, assert valid PEM.
+- `connect_rewrap_fails_with_jwt_bearer_returns_401` — expected-failure test: attempt rewrap with a fake JWT bearer, assert HTTP 401 with Connect `unauthenticated` code in reason. **Validates transport works end-to-end.**
+- `connect_rewrap_with_cwt_bearer_also_returns_401_for_now` — companion test documenting intended end state; also expected to fail until platform-side CWT validation lands.
+
+### Examples
+
+- `examples/kas_sanity_test.rs`: hardcoded REST URL → discovery or `for_kas_connect`.
+- `examples/create_tdf_platform.rs`, `examples/cross_sdk_test.rs`, `examples/xtest_cli.rs`: two-line constructor migration each.
+- `examples/mock_kas_server.rs`: add Connect routes (`/kas.AccessService/Rewrap`, `/kas.AccessService/PublicKey`) alongside existing REST routes — multi-profile mock.
+
+## Migration impact
+
+**Breaking change:** `KasClient::new(base_url, token)` → `KasClient::new(&config, token)`. Justifies a `0.12.x` → `0.13.0` minor bump (pre-1.0).
+
+All in-repo callers (examples, tests) migrate in this same PR. Two-line change per site:
+
+```rust
+// before
+let kas = KasClient::new("https://kas.example.com", token)?;
+
+// after
+let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+let kas = KasClient::new(&cfg, token)?;
+```
+
+CHANGELOG entry calls this out and points downstream consumers at the same one-liner.
+
+## Acceptance criteria
+
+- `KasClient::rewrap_*` and `fetch_kas_*public_key_connect` use the resolved Connect URLs against a platform that advertises them.
+- `cargo test --all-features` passes with mocks updated to Connect routes.
+- Connect error envelope (`{code, message}`) parsed into `KasError` reason strings; mock 401 test passes.
+- `cargo test --all-features --ignored` against `KAS_INTEGRATION_TESTS=1`:
+  - well-known fetch succeeds against `platform.arkavo.net`.
+  - Connect `PublicKey` fetch succeeds.
+  - Connect `Rewrap` returns HTTP 401 with Connect `unauthenticated` in the reason (expected failure, documents next blocker).
+- `cargo clippy --all-targets --all-features -- -D warnings` clean.
+- `cargo fmt --all --check` clean.
+- `RUSTFLAGS="-D warnings" cargo build --all-features` clean.
+- All examples compile; `kas_sanity_test.rs` runs against the new transport (or is updated to be skipped without the env var, matching existing convention).
+- README + module-level doc-comments updated to reference Connect endpoints and well-known discovery.
+
+## Open follow-ups (not this PR)
+
+- **#43 / WASM mirror:** apply the same transport switch to `crates/wasm/src/kas.rs` using `web_sys::Fetch`. Re-use `KasEndpoints` and `OpentdfConfiguration` from the protocol crate or a wasm-compatible discovery module.
+- **#46 / OIDC auth:** consume the `idp` block from `OpentdfConfiguration` to wire token acquisition. The deserialized `IdpConfig` is already in place for this.
+- **CWT client-side:** add CWT verification helpers (COSE_Sign1 over ES256 + COSE Key Set fetch from `cose_keys_uri`) once the platform validates CWT bearers on KAS.
+- **Remove legacy REST routes** from `examples/mock_kas_server.rs` once no in-repo example targets them.

--- a/examples/create_tdf_platform.rs
+++ b/examples/create_tdf_platform.rs
@@ -47,7 +47,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Fetch KAS public key
     println!("1. Fetching KAS public key...");
     let http_client = reqwest::Client::new();
-    let kas_key_response = opentdf::kas_key::fetch_kas_public_key(&kas_url, &http_client).await?;
+    // Strip trailing /kas if present — Connect endpoints are at the platform root
+    let kas_root = kas_url
+        .trim_end_matches('/')
+        .strip_suffix("/kas")
+        .unwrap_or(kas_url.trim_end_matches('/'));
+    let kas_pk_url = format!("{}/kas.AccessService/PublicKey", kas_root);
+    let kas_key_response =
+        opentdf::kas_key::fetch_kas_public_key_connect(&kas_pk_url, &http_client).await?;
     println!("   ✓ Fetched key ID: {}", kas_key_response.kid);
     println!();
 

--- a/examples/jwt_helper.rs
+++ b/examples/jwt_helper.rs
@@ -146,7 +146,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\nFull token length: {} characters", signed_token.len());
 
     println!("\n=== Usage in KAS Client ===");
-    println!("let kas_client = KasClient::new(kas_url, oauth_token)?;");
+    println!("let config = OpentdfConfiguration::for_kas_connect(kas_url);");
+    println!("let kas_client = KasClient::new(&config, oauth_token)?;");
     println!("let payload_key = kas_client.rewrap_standard_tdf(&manifest, &signed_token).await?;");
 
     Ok(())

--- a/examples/kas_decrypt.rs
+++ b/examples/kas_decrypt.rs
@@ -9,7 +9,9 @@
 //! cargo run --example kas_decrypt --features kas -- /path/to/file.tdf
 //! ```
 
-use opentdf::{TdfArchive, kas::KasClient, manifest::TdfManifestExt};
+use opentdf::{
+    TdfArchive, kas::KasClient, kas_discovery::OpentdfConfiguration, manifest::TdfManifestExt,
+};
 use std::env;
 
 #[tokio::main]
@@ -40,7 +42,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create KAS client
     println!("1. Creating KAS client...");
-    let kas_client = match KasClient::new(&kas_url, &kas_token) {
+    let config = OpentdfConfiguration::for_kas_connect(&kas_url);
+    let kas_client = match KasClient::new(&config, &kas_token) {
         Ok(client) => {
             println!("   ✓ KAS client created");
             client

--- a/examples/kas_sanity_test.rs
+++ b/examples/kas_sanity_test.rs
@@ -6,12 +6,14 @@
 use opentdf::{Policy, jsonrpc::TdfJsonRpc};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== ZTDF-JSON Sanity Test with https://100.arkavo.net/kas.AccessService/Rewrap ===\n");
+    println!(
+        "=== ZTDF-JSON Sanity Test with https://100.arkavo.net/kas.AccessService/Rewrap ===\n"
+    );
 
     // Test data
     let test_data = b"Sanity test: Hello from ZTDF-JSON!";
     let _kas_base_url = "https://100.arkavo.net";
-    let kas_url = "https://100.arkavo.net/kas.AccessService/Rewrap";  // for display only
+    let kas_url = "https://100.arkavo.net/kas.AccessService/Rewrap"; // for display only
 
     println!("1. Creating policy...");
     let policy = Policy::new(

--- a/examples/kas_sanity_test.rs
+++ b/examples/kas_sanity_test.rs
@@ -6,11 +6,12 @@
 use opentdf::{Policy, jsonrpc::TdfJsonRpc};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== ZTDF-JSON Sanity Test with https://100.arkavo.net/kas/v2 ===\n");
+    println!("=== ZTDF-JSON Sanity Test with https://100.arkavo.net/kas.AccessService/Rewrap ===\n");
 
     // Test data
     let test_data = b"Sanity test: Hello from ZTDF-JSON!";
-    let kas_url = "https://100.arkavo.net/kas/v2/rewrap";
+    let _kas_base_url = "https://100.arkavo.net";
+    let kas_url = "https://100.arkavo.net/kas.AccessService/Rewrap";  // for display only
 
     println!("1. Creating policy...");
     let policy = Policy::new(

--- a/examples/mock_kas_server.rs
+++ b/examples/mock_kas_server.rs
@@ -92,6 +92,21 @@ impl AppState {
         &self.rsa_public_key_pem
     }
 
+    /// Return (pem, kid) for a given algorithm string.
+    ///
+    /// Accepts the same algorithm tokens as the legacy GET handler:
+    /// - `"ec"`, `"ec:secp256r1"`, etc. → EC P-256 key
+    /// - anything else (including `""` or `"rsa:2048"`) → RSA-2048 key
+    fn public_keys_for(&self, algorithm: &str) -> (String, String) {
+        if algorithm.starts_with("ec:") || algorithm == "ec" {
+            let pem = self.ec_public_key_pem().to_string();
+            (pem, "ec-1".to_string())
+        } else {
+            let pem = self.rsa_public_key_pem().to_string();
+            (pem, "rsa-1".to_string())
+        }
+    }
+
     /// Store a symmetric key for a policy ID
     #[allow(dead_code)]
     fn store_key(&self, policy_id: &str, key: Vec<u8>) {
@@ -269,6 +284,33 @@ async fn get_public_key_with_algorithm(
     };
 
     Json(PublicKeyResponse { public_key })
+}
+
+/// Request body for ConnectRPC PublicKey endpoint
+#[derive(Deserialize, Default)]
+struct PublicKeyConnectRequest {
+    #[serde(default)]
+    algorithm: Option<String>,
+}
+
+/// Get KAS public key (ConnectRPC POST style)
+///
+/// Accepts an optional JSON body `{"algorithm":"ec:secp256r1"}`.
+/// Defaults to RSA-2048 when no algorithm is specified.
+async fn get_public_key_connect(
+    State(state): State<AppState>,
+    body: Option<Json<PublicKeyConnectRequest>>,
+) -> impl IntoResponse {
+    let algorithm = body
+        .and_then(|Json(req)| req.algorithm)
+        .unwrap_or_else(|| "rsa:2048".to_string());
+
+    let (pem, kid) = state.public_keys_for(&algorithm);
+
+    Json(serde_json::json!({
+        "publicKey": pem,
+        "kid": kid,
+    }))
 }
 
 /// Rewrap key endpoint
@@ -697,10 +739,12 @@ async fn main() {
     println!("EC public key: {}", ec_key_path.display());
     println!();
     println!("Endpoints:");
-    println!("  GET  /health                  - Health check");
-    println!("  GET  /kas/v2/kas_public_key   - Get KAS public key");
-    println!("  POST /kas/v2/rewrap           - Rewrap key");
-    println!("  POST /token                   - Get OAuth token");
+    println!("  GET  /health                          - Health check");
+    println!("  GET  /kas/v2/kas_public_key           - Get KAS public key (REST)");
+    println!("  POST /kas/v2/rewrap                   - Rewrap key (REST)");
+    println!("  POST /token                           - Get OAuth token");
+    println!("  POST /kas.AccessService/PublicKey     - Get KAS public key (ConnectRPC)");
+    println!("  POST /kas.AccessService/Rewrap        - Rewrap key (ConnectRPC)");
     println!();
 
     let app = Router::new()
@@ -708,6 +752,8 @@ async fn main() {
         .route("/kas/v2/kas_public_key", get(get_public_key_with_algorithm))
         .route("/kas/v2/rewrap", post(rewrap))
         .route("/token", post(token))
+        .route("/kas.AccessService/PublicKey", post(get_public_key_connect))
+        .route("/kas.AccessService/Rewrap", post(rewrap))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", port);

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -47,7 +47,10 @@ impl<'a> TdfEntry<'a> {
     /// ```no_run
     /// # use opentdf::{TdfArchive, kas::KasClient};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let kas_client = KasClient::new("https://kas.example.com", "token")?;
+    /// let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+    ///     "https://kas.example.com",
+    /// );
+    /// let kas_client = KasClient::new(&config, "token")?;
     /// let mut archive = TdfArchive::open("example.tdf")?;
     /// let entry = archive.by_index()?;
     /// let plaintext = entry.decrypt_with_kas(&kas_client).await?;
@@ -306,7 +309,10 @@ impl TdfArchive<File> {
     /// ```no_run
     /// # use opentdf::{TdfArchive, kas::KasClient};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let kas_client = KasClient::new("https://kas.example.com", "token")?;
+    /// let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+    ///     "https://kas.example.com",
+    /// );
+    /// let kas_client = KasClient::new(&config, "token")?;
     /// let plaintext = TdfArchive::open_and_decrypt("example.tdf", &kas_client).await?;
     /// # Ok(())
     /// # }

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -9,7 +9,7 @@
 //! 1. Generate ephemeral RSA-2048 key pair
 //! 2. Build unsigned rewrap request with manifest data
 //! 3. Accept pre-signed JWT token (ES256) - see `examples/jwt_helper.rs`
-//! 4. POST to KAS `/v2/rewrap` endpoint
+//! 4. POST to KAS `/kas.AccessService/Rewrap` (ConnectRPC) endpoint
 //! 5. Receive RSA-encrypted wrapped key
 //! 6. Unwrap key using RSA-OAEP (SHA-1 default, SHA-256 available)
 //!
@@ -17,7 +17,7 @@
 //! 1. Generate ephemeral EC P-256 key pair
 //! 2. Build unsigned rewrap request with manifest data
 //! 3. Accept pre-signed JWT token (ES256) - see `examples/jwt_helper.rs`
-//! 4. POST to KAS `/v2/rewrap` endpoint
+//! 4. POST to KAS `/kas.AccessService/Rewrap` (ConnectRPC) endpoint
 //! 5. Receive wrapped key and session public key
 //! 6. Unwrap key using ECDH + HKDF + AES-GCM
 //!
@@ -282,14 +282,15 @@ impl KasClient {
         })
     }
 
-    /// Internal helper for sending signed rewrap requests to KAS
+    /// Internal helper for sending signed rewrap requests to KAS via ConnectRPC
     ///
-    /// Handles HTTP POST, error mapping for 401/403, and JSON response parsing.
+    /// Handles HTTP POST to /kas.AccessService/Rewrap, parses Connect error
+    /// envelopes for richer error messages, and deserializes the response.
     async fn send_rewrap_request(
         &self,
         signed_request: &SignedRewrapRequest,
     ) -> Result<RewrapResponse, KasError> {
-        let rewrap_endpoint = format!("{}/kas/v2/rewrap", self.base_url);
+        let rewrap_endpoint = format!("{}/kas.AccessService/Rewrap", self.base_url);
 
         let response = self
             .http_client
@@ -307,17 +308,25 @@ impl KasClient {
         let status = response.status();
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
+            let detail = crate::kas_discovery::parse_connect_error(&error_body)
+                .map(|e| format!("{}: {}", e.code, e.message))
+                .unwrap_or_else(|| {
+                    if error_body.is_empty() {
+                        format!("HTTP {}", status)
+                    } else {
+                        error_body.clone()
+                    }
+                });
+
             return Err(match status.as_u16() {
-                401 => KasError::AuthenticationFailed {
-                    reason: "Invalid or missing OAuth token".to_string(),
-                },
+                401 => KasError::AuthenticationFailed { reason: detail },
                 403 => KasError::AccessDenied {
                     resource: "KAS endpoint".to_string(),
-                    reason: error_body,
+                    reason: detail,
                 },
                 _ => KasError::HttpError {
                     status: status.as_u16(),
-                    message: format!("HTTP {}: {}", status, error_body),
+                    message: detail,
                 },
             });
         }
@@ -337,7 +346,7 @@ impl KasClient {
     /// 1. Generate RSA-2048 ephemeral key pair (Standard TDF uses RSA)
     /// 2. Build unsigned rewrap request
     /// 3. Sign request with internal signing key to create JWT (RS256)
-    /// 4. POST to KAS /v2/rewrap endpoint with signed JWT
+    /// 4. POST to KAS /kas.AccessService/Rewrap (ConnectRPC) endpoint with signed JWT
     /// 5. Unwrap the returned key using RSA-OAEP
     ///
     /// # Arguments

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -173,11 +173,6 @@ impl EphemeralKeyPair {
 #[cfg(feature = "kas-client")]
 pub struct KasClient {
     http_client: Client,
-    /// Backwards-compatible base URL field, derived from the resolved
-    /// `OpentdfConfiguration::kas.uri`. **Not used for routing** — internal
-    /// requests go through `endpoints.rewrap_url`. Retained as `pub` to avoid
-    /// breaking downstream callers that read this field directly.
-    pub base_url: String,
     endpoints: crate::kas_discovery::KasEndpoints,
     oauth_token: String,
     signing_key: PrivateDecryptingKey,
@@ -236,18 +231,8 @@ impl KasClient {
             }
         })?;
 
-        // Derive base_url from the kas block's `uri` if present, else from the
-        // rewrap URL host. Used only for backwards-compat field access; not
-        // used for routing (we use endpoints.rewrap_url).
-        let base_url = config
-            .kas
-            .as_ref()
-            .map(|k| k.uri.trim_end_matches('/').to_string())
-            .unwrap_or_default();
-
         Ok(Self {
             http_client,
-            base_url,
             endpoints,
             oauth_token: oauth_token.into(),
             signing_key,

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -201,6 +201,8 @@ impl KasClient {
     /// - **HTTPS required**: HTTP is only allowed for `localhost`/`127.0.0.1`/`::1` (development use)
     /// - **SSRF protection**: Private and link-local IP addresses are rejected (IPv4 and IPv6, including IPv4-mapped literals)
     /// - **Scheme validation**: Only `http` and `https` schemes are accepted
+    /// - **No redirects**: The rewrap HTTP client follows no redirects, so a 3xx
+    ///   cannot re-issue the bearer-carrying request to an unvalidated host
     ///
     /// # Note
     ///
@@ -216,8 +218,14 @@ impl KasClient {
         // HTTPS / scheme / SSRF constraints before returning.
         let endpoints = crate::kas_discovery::KasEndpoints::from_config(config)?;
 
+        // Disable redirect following. The KAS rewrap endpoint is an RPC target
+        // that should never redirect; allowing redirects would let a 3xx from a
+        // validated host re-issue the bearer-carrying request to an unvalidated
+        // one (e.g. an internal address), since `validate_kas_url` only runs on
+        // the initial URL, not per-hop.
         let http_client = Client::builder()
             .timeout(std::time::Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| KasError::HttpError {
                 status: 0,

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -201,9 +201,10 @@ impl KasClient {
     ///
     /// # Security
     ///
-    /// The resolved KAS rewrap URL is validated:
+    /// Both resolved KAS URLs (rewrap and public-key) are validated during
+    /// endpoint resolution (see [`crate::kas_discovery::validate_kas_url`]):
     /// - **HTTPS required**: HTTP is only allowed for `localhost`/`127.0.0.1`/`::1` (development use)
-    /// - **SSRF protection**: Private and link-local IP addresses are rejected
+    /// - **SSRF protection**: Private and link-local IP addresses are rejected (IPv4 and IPv6, including IPv4-mapped literals)
     /// - **Scheme validation**: Only `http` and `https` schemes are accepted
     ///
     /// # Note
@@ -216,10 +217,9 @@ impl KasClient {
         config: &crate::kas_discovery::OpentdfConfiguration,
         oauth_token: impl Into<String>,
     ) -> Result<Self, KasError> {
+        // `from_config` validates both the rewrap and public-key URLs for
+        // HTTPS / scheme / SSRF constraints before returning.
         let endpoints = crate::kas_discovery::KasEndpoints::from_config(config)?;
-
-        // Validate the rewrap URL — the public_key_url will be validated when first used.
-        Self::validate_kas_url(&endpoints.rewrap_url)?;
 
         let http_client = Client::builder()
             .timeout(std::time::Duration::from_secs(30))
@@ -254,50 +254,6 @@ impl KasClient {
         })
     }
 
-    /// Validate a KAS URL for HTTPS / SSRF / scheme constraints.
-    fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
-        let parsed = url::Url::parse(url_str)
-            .map_err(|e| KasError::InvalidUrl(format!("Failed to parse URL: {e}")))?;
-
-        match parsed.scheme() {
-            "https" => {}
-            "http" => {
-                let is_loopback = match parsed.host() {
-                    Some(url::Host::Domain("localhost")) => true,
-                    Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-                    Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-                    _ => false,
-                };
-                if !is_loopback {
-                    return Err(KasError::InvalidUrl(
-                        "KAS URL must use HTTPS (HTTP only allowed for localhost)".to_string(),
-                    ));
-                }
-            }
-            scheme => {
-                return Err(KasError::InvalidUrl(format!(
-                    "Unsupported URL scheme '{scheme}', must be https"
-                )));
-            }
-        }
-
-        if let Some(host) = parsed.host() {
-            match host {
-                url::Host::Ipv4(ip) => {
-                    if ip.is_private() || ip.is_link_local() {
-                        return Err(KasError::InvalidUrl(
-                            "KAS URL must not target private or link-local IP addresses"
-                                .to_string(),
-                        ));
-                    }
-                }
-                url::Host::Ipv6(_) | url::Host::Domain(_) => {}
-            }
-        }
-
-        Ok(())
-    }
-
     /// Internal helper for sending signed rewrap requests to KAS via ConnectRPC
     ///
     /// Handles HTTP POST to /kas.AccessService/Rewrap, parses Connect error
@@ -314,9 +270,10 @@ impl KasClient {
             .json(signed_request)
             .send()
             .await
-            .map_err(|e| KasError::HttpError {
-                status: 0,
-                message: format!("HTTP request failed: {}", e),
+            .map_err(|e| KasError::RequestError {
+                method: "POST".to_string(),
+                url: self.endpoints.rewrap_url.clone(),
+                reason: e.to_string(),
             })?;
 
         let status = response.status();

--- a/src/kas.rs
+++ b/src/kas.rs
@@ -30,20 +30,17 @@
 //!
 //! ```no_run
 //! use opentdf::kas::KasClient;
+//! use opentdf::kas_discovery::OpentdfConfiguration;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = KasClient::new(
-//!     "https://kas.example.com",
-//!     "oauth_token_here",
-//! )?;
+//! let config = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+//! let client = KasClient::new(&config, "oauth_token_here")?;
 //!
-//! // Create a test manifest
 //! let manifest = opentdf::TdfManifest::new(
 //!     "0.payload".to_string(),
 //!     "https://kas.example.com".to_string()
 //! );
 //!
-//! // Unwrap a key from a TDF manifest (JWT signing handled internally)
 //! let payload_key = client.rewrap_standard_tdf(&manifest).await?;
 //! # Ok(())
 //! # }
@@ -176,44 +173,92 @@ impl EphemeralKeyPair {
 #[cfg(feature = "kas-client")]
 pub struct KasClient {
     http_client: Client,
-    base_url: String,
+    /// Backwards-compatible base URL field, derived from the resolved
+    /// `OpentdfConfiguration::kas.uri`. **Not used for routing** — internal
+    /// requests go through `endpoints.rewrap_url`. Retained as `pub` to avoid
+    /// breaking downstream callers that read this field directly.
+    pub base_url: String,
+    endpoints: crate::kas_discovery::KasEndpoints,
     oauth_token: String,
-    /// aws-lc-rs RSA private key for JWT signing
     signing_key: PrivateDecryptingKey,
 }
 
 #[cfg(feature = "kas-client")]
 impl KasClient {
-    /// Create a new KAS client
+    /// Create a new KAS client from a resolved configuration document.
     ///
     /// # Arguments
     ///
-    /// * `base_url` - Base URL of the KAS service (e.g., `"https://kas.example.com"`)
-    /// * `oauth_token` - OAuth bearer token for authentication
+    /// * `config` - A pre-resolved `OpentdfConfiguration`. Obtain via
+    ///   `fetch_well_known(...)` for discovery-driven setups, or build
+    ///   directly with `OpentdfConfiguration::for_kas_connect(base_url)`
+    ///   when the platform doesn't expose `/.well-known/opentdf-configuration`.
+    ///   `OpentdfConfiguration::for_kas_legacy_rest(base_url)` is the escape
+    ///   hatch for pre-ConnectRPC deployments.
+    /// * `oauth_token` - Bearer token sent in the `Authorization` header.
+    ///   Opaque passthrough: pass a JWT or a base64url-encoded CWT — the
+    ///   server decides how to validate.
     ///
     /// # Security
     ///
-    /// The URL is validated for security:
+    /// The resolved KAS rewrap URL is validated:
     /// - **HTTPS required**: HTTP is only allowed for `localhost`/`127.0.0.1`/`::1` (development use)
     /// - **SSRF protection**: Private and link-local IP addresses are rejected
     /// - **Scheme validation**: Only `http` and `https` schemes are accepted
     ///
     /// # Note
     ///
-    /// This client generates an ephemeral RSA-2048 key pair for signing JWT rewrap requests.
-    /// The JWT signature is verified by KAS when DPoP is enabled, otherwise it's parsed without verification.
-    /// Uses aws-lc-rs for constant-time RSA operations (FIPS validated).
+    /// This client generates an ephemeral RSA-2048 key pair for signing the
+    /// inner JWT rewrap request envelope. That is separate from the access
+    /// token — the inner JWT is the rewrap-request signature; the `oauth_token`
+    /// is the platform-issued access token.
     pub fn new(
-        base_url: impl Into<String>,
+        config: &crate::kas_discovery::OpentdfConfiguration,
         oauth_token: impl Into<String>,
     ) -> Result<Self, KasError> {
-        let base_url: String = base_url.into();
+        let endpoints = crate::kas_discovery::KasEndpoints::from_config(config)?;
 
-        // Parse and validate KAS URL
-        let parsed = url::Url::parse(&base_url)
+        // Validate the rewrap URL — the public_key_url will be validated when first used.
+        Self::validate_kas_url(&endpoints.rewrap_url)?;
+
+        let http_client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| KasError::HttpError {
+                status: 0,
+                message: format!("Failed to build HTTP client: {}", e),
+            })?;
+
+        let signing_key = PrivateDecryptingKey::generate(KeySize::Rsa2048).map_err(|e| {
+            KasError::CryptoError {
+                operation: "generate_signing_key".to_string(),
+                reason: format!("Failed to generate RSA signing key: {:?}", e),
+            }
+        })?;
+
+        // Derive base_url from the kas block's `uri` if present, else from the
+        // rewrap URL host. Used only for backwards-compat field access; not
+        // used for routing (we use endpoints.rewrap_url).
+        let base_url = config
+            .kas
+            .as_ref()
+            .map(|k| k.uri.trim_end_matches('/').to_string())
+            .unwrap_or_default();
+
+        Ok(Self {
+            http_client,
+            base_url,
+            endpoints,
+            oauth_token: oauth_token.into(),
+            signing_key,
+        })
+    }
+
+    /// Validate a KAS URL for HTTPS / SSRF / scheme constraints.
+    fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
+        let parsed = url::Url::parse(url_str)
             .map_err(|e| KasError::InvalidUrl(format!("Failed to parse URL: {e}")))?;
 
-        // Enforce HTTPS (allow HTTP only for loopback/localhost for development)
         match parsed.scheme() {
             "https" => {}
             "http" => {
@@ -236,7 +281,6 @@ impl KasClient {
             }
         }
 
-        // Block requests to private/link-local IP ranges (SSRF protection)
         if let Some(host) = parsed.host() {
             match host {
                 url::Host::Ipv4(ip) => {
@@ -247,39 +291,11 @@ impl KasClient {
                         ));
                     }
                 }
-                url::Host::Ipv6(_) => {
-                    // IPv6 loopback (::1) is already handled by the HTTP/HTTPS check above.
-                    // Rust stable doesn't expose is_unicast_link_local() for Ipv6Addr,
-                    // but the HTTPS requirement blocks most SSRF vectors for non-loopback IPv6.
-                }
-                url::Host::Domain(_) => {
-                    // Domain names are allowed — HTTPS + TLS certificate validates identity.
-                }
+                url::Host::Ipv6(_) | url::Host::Domain(_) => {}
             }
         }
 
-        let http_client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| KasError::HttpError {
-                status: 0,
-                message: format!("Failed to build HTTP client: {}", e),
-            })?;
-
-        // Generate RSA-2048 key pair for JWT signing (DPoP key) using aws-lc-rs
-        let signing_key = PrivateDecryptingKey::generate(KeySize::Rsa2048).map_err(|e| {
-            KasError::CryptoError {
-                operation: "generate_signing_key".to_string(),
-                reason: format!("Failed to generate RSA signing key: {:?}", e),
-            }
-        })?;
-
-        Ok(Self {
-            http_client,
-            base_url,
-            oauth_token: oauth_token.into(),
-            signing_key,
-        })
+        Ok(())
     }
 
     /// Internal helper for sending signed rewrap requests to KAS via ConnectRPC
@@ -290,11 +306,9 @@ impl KasClient {
         &self,
         signed_request: &SignedRewrapRequest,
     ) -> Result<RewrapResponse, KasError> {
-        let rewrap_endpoint = format!("{}/kas.AccessService/Rewrap", self.base_url);
-
         let response = self
             .http_client
-            .post(&rewrap_endpoint)
+            .post(&self.endpoints.rewrap_url)
             .header("Authorization", format!("Bearer {}", self.oauth_token))
             .header("Content-Type", "application/json")
             .json(signed_request)
@@ -878,87 +892,74 @@ mod tests {
     #[cfg(feature = "kas-client")]
     mod url_validation_tests {
         use super::*;
+        use crate::kas_discovery::OpentdfConfiguration;
 
-        /// Helper to extract the error from a KasClient::new result
-        fn expect_err(result: Result<KasClient, KasError>) -> KasError {
-            match result {
+        /// Helper: construct via for_kas_connect and capture the error.
+        fn expect_err(url: &str) -> KasError {
+            let cfg = OpentdfConfiguration::for_kas_connect(url);
+            match KasClient::new(&cfg, "token") {
                 Err(e) => e,
-                Ok(_) => panic!("Expected error, got Ok"),
+                Ok(_) => panic!("Expected error for {url}, got Ok"),
             }
         }
 
         #[test]
         fn test_kas_rejects_http_url() {
-            let err = expect_err(KasClient::new("http://evil.com", "token"));
-            assert!(
-                matches!(err, KasError::InvalidUrl(_)),
-                "Expected InvalidUrl, got: {err}"
-            );
+            let err = expect_err("http://evil.com");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
             assert!(err.to_string().contains("HTTPS"));
         }
 
         #[test]
         fn test_kas_accepts_https_url() {
-            let result = KasClient::new("https://kas.example.com", "token");
-            assert!(result.is_ok(), "HTTPS URL should be accepted");
+            let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+            assert!(KasClient::new(&cfg, "token").is_ok());
         }
 
         #[test]
         fn test_kas_allows_http_localhost() {
-            let result = KasClient::new("http://127.0.0.1:8080", "token");
-            assert!(
-                result.is_ok(),
-                "HTTP localhost (127.0.0.1) should be allowed"
-            );
-
-            let result = KasClient::new("http://localhost:8080", "token");
-            assert!(result.is_ok(), "HTTP localhost should be allowed");
-
-            let result = KasClient::new("http://[::1]:8080", "token");
-            assert!(result.is_ok(), "HTTP IPv6 loopback should be allowed");
+            for base in [
+                "http://127.0.0.1:8080",
+                "http://localhost:8080",
+                "http://[::1]:8080",
+            ] {
+                let cfg = OpentdfConfiguration::for_kas_connect(base);
+                assert!(
+                    KasClient::new(&cfg, "token").is_ok(),
+                    "HTTP loopback {base} should be allowed"
+                );
+            }
         }
 
         #[test]
         fn test_kas_rejects_private_ip() {
-            let err = expect_err(KasClient::new("https://10.0.0.1", "token"));
-            assert!(
-                matches!(err, KasError::InvalidUrl(_)),
-                "Expected InvalidUrl for private IP, got: {err}"
-            );
-
-            assert!(
-                KasClient::new("https://172.16.0.1", "token").is_err(),
-                "172.16.x.x should be rejected"
-            );
-            assert!(
-                KasClient::new("https://192.168.1.1", "token").is_err(),
-                "192.168.x.x should be rejected"
-            );
+            for base in [
+                "https://10.0.0.1",
+                "https://172.16.0.1",
+                "https://192.168.1.1",
+            ] {
+                let err = expect_err(base);
+                assert!(matches!(err, KasError::InvalidUrl(_)), "{base}: {err}");
+            }
         }
 
         #[test]
         fn test_kas_rejects_metadata_ip() {
-            let err = expect_err(KasClient::new("http://169.254.169.254", "token"));
-            assert!(
-                matches!(err, KasError::InvalidUrl(_)),
-                "Expected InvalidUrl for metadata IP, got: {err}"
-            );
+            let err = expect_err("http://169.254.169.254");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
         }
 
         #[test]
         fn test_kas_rejects_invalid_scheme() {
-            let err = expect_err(KasClient::new("ftp://kas.example.com", "token"));
-            assert!(
-                matches!(err, KasError::InvalidUrl(_)),
-                "Expected InvalidUrl for ftp scheme, got: {err}"
-            );
+            let err = expect_err("ftp://kas.example.com");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
             assert!(err.to_string().contains("ftp"));
         }
 
         #[test]
         fn test_kas_rejects_invalid_url() {
-            let err = expect_err(KasClient::new("not-a-url", "token"));
-            assert!(matches!(err, KasError::InvalidUrl(_)));
+            let err = expect_err("not-a-url");
+            assert!(matches!(err, KasError::InvalidUrl(_)), "got: {err}");
         }
     }
 }

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -1,0 +1,7 @@
+//! KAS endpoint discovery via /.well-known/opentdf-configuration
+//!
+//! Provides types for deserializing the platform's well-known configuration
+//! document, plus URL-resolution logic that prefers ConnectRPC endpoints
+//! and falls back to legacy REST paths when only REST is advertised.
+
+#![cfg(feature = "kas-client")]

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -149,11 +149,11 @@ impl KasEndpoints {
 /// - **Scheme**: only `http` and `https` are accepted.
 /// - **HTTPS required**: plain `http` is allowed only for loopback hosts
 ///   (`localhost`, `127.0.0.0/8`, `::1`) for local development.
-/// - **SSRF protection**: private and link-local addresses are rejected,
-///   covering IPv4 (`10/8`, `172.16/12`, `192.168/16`, `169.254/16`), IPv6
-///   unique-local (`fc00::/7`) and link-local (`fe80::/10`), and IPv4-mapped
-///   IPv6 literals (e.g. `::ffff:169.254.169.254`), which are folded back to
-///   their IPv4 form before the check.
+/// - **SSRF protection**: private, link-local, and unspecified addresses are
+///   rejected, covering IPv4 (`10/8`, `172.16/12`, `192.168/16`, `169.254/16`,
+///   `0.0.0.0`), IPv6 unique-local (`fc00::/7`), link-local (`fe80::/10`) and
+///   `::`, and IPv4-mapped IPv6 literals (e.g. `::ffff:169.254.169.254`), which
+///   are folded back to their IPv4 form before the check.
 pub fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
     use std::net::IpAddr;
 
@@ -207,8 +207,14 @@ pub fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
 fn is_blocked_ip(ip: &std::net::IpAddr) -> bool {
     use std::net::IpAddr;
     match ip {
-        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        // `0.0.0.0` (unspecified) routes to localhost on most systems, so block
+        // it alongside the private and link-local ranges.
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_unspecified(),
         IpAddr::V6(v6) => {
+            if v6.is_unspecified() {
+                // `::` behaves like `0.0.0.0`.
+                return true;
+            }
             let first = v6.segments()[0];
             // Unique-local fc00::/7 or unicast link-local fe80::/10.
             (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
@@ -509,6 +515,19 @@ mod tests {
                 "{url} should be rejected"
             );
         }
+    }
+
+    #[test]
+    fn validate_kas_url_rejects_unspecified_addresses() {
+        // 0.0.0.0 / :: route to localhost on most systems.
+        assert!(matches!(
+            validate_kas_url("https://0.0.0.0/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
+        assert!(matches!(
+            validate_kas_url("https://[::]/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
     }
 
     #[test]

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -163,6 +163,45 @@ pub fn parse_connect_error(body: &str) -> Option<ConnectError> {
     Some(parsed)
 }
 
+/// Fetch the platform's `/.well-known/opentdf-configuration` document.
+///
+/// `platform_url` should be the platform's base URL (e.g.,
+/// `"https://platform.arkavo.net"`). A trailing slash is tolerated.
+pub async fn fetch_well_known(
+    platform_url: &str,
+    http_client: &reqwest::Client,
+) -> Result<OpentdfConfiguration, KasError> {
+    let base = platform_url.trim_end_matches('/');
+    let url = format!("{}/.well-known/opentdf-configuration", base);
+
+    let response = http_client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| KasError::RequestError {
+            method: "GET".to_string(),
+            url: url.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(KasError::HttpError {
+            status: status.as_u16(),
+            message: format!("GET {} -> {}: {}", url, status, body),
+        });
+    }
+
+    response
+        .json::<OpentdfConfiguration>()
+        .await
+        .map_err(|e| KasError::InvalidResponse {
+            reason: format!("Failed to parse well-known JSON: {}", e),
+            expected: Some("OpentdfConfiguration".to_string()),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,5 +389,61 @@ mod tests {
         assert!(parse_connect_error("not json").is_none());
         assert!(parse_connect_error("").is_none());
         assert!(parse_connect_error(r#"{"unrelated":"shape"}"#).is_none());
+    }
+
+    use mockito::Server;
+
+    #[tokio::test]
+    async fn fetch_well_known_returns_parsed_config() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(PLATFORM_WELL_KNOWN)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cfg = fetch_well_known(&server.url(), &http).await.unwrap();
+        assert!(cfg.kas.is_some());
+        assert_eq!(
+            cfg.platform_issuer.as_deref(),
+            Some("https://identity.arkavo.net")
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_well_known_404_returns_http_error() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let err = fetch_well_known(&server.url(), &http).await.unwrap_err();
+        match err {
+            opentdf_protocol::KasError::HttpError { status, .. } => assert_eq!(status, 404),
+            other => panic!("expected HttpError(404), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_well_known_handles_trailing_slash() {
+        let mut server = Server::new_async().await;
+        let _m = server
+            .mock("GET", "/.well-known/opentdf-configuration")
+            .with_status(200)
+            .with_body(PLATFORM_WELL_KNOWN)
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let url_with_slash = format!("{}/", server.url());
+        let cfg = fetch_well_known(&url_with_slash, &http).await.unwrap();
+        assert!(cfg.kas.is_some());
     }
 }

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -5,3 +5,114 @@
 //! and falls back to legacy REST paths when only REST is advertised.
 
 #![cfg(feature = "kas-client")]
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpentdfConfiguration {
+    pub kas: Option<KasConfig>,
+    pub idp: Option<IdpConfig>,
+    pub platform_issuer: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KasConfig {
+    pub uri: String,
+    #[serde(default)]
+    pub algorithms: Vec<String>,
+    pub public_key_url: Option<String>,
+    pub rewrap_url: Option<String>,
+    pub connect_public_key_url: Option<String>,
+    pub connect_rewrap_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdpConfig {
+    pub issuer: String,
+    pub jwks_uri: Option<String>,
+    pub cose_keys_uri: Option<String>,
+    pub token_endpoint: Option<String>,
+    pub authorization_endpoint: Option<String>,
+    pub userinfo_endpoint: Option<String>,
+    pub access_token_format: Option<String>,
+    #[serde(default)]
+    pub id_token_signing_alg_values_supported: Vec<String>,
+    #[serde(default)]
+    pub response_types_supported: Vec<String>,
+    #[serde(default)]
+    pub subject_types_supported: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from https://platform.arkavo.net/.well-known/opentdf-configuration on 2026-05-28
+    const PLATFORM_WELL_KNOWN: &str = r#"{
+        "health": { "endpoint": "/healthz" },
+        "idp": {
+            "access_token_format": "application/cwt",
+            "authorization_endpoint": "https://identity.arkavo.net/oauth/authorize",
+            "cose_keys_uri": "https://identity.arkavo.net/.well-known/cose-keys",
+            "id_token_signing_alg_values_supported": ["ES256"],
+            "issuer": "https://identity.arkavo.net",
+            "jwks_uri": "https://identity.arkavo.net/.well-known/jwks.json",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "token_endpoint": "https://identity.arkavo.net/oauth/token",
+            "userinfo_endpoint": "https://identity.arkavo.net/oauth/userinfo"
+        },
+        "kas": {
+            "algorithms": ["ec:secp256r1", "rsa:2048"],
+            "connect_public_key_url": "https://platform.arkavo.net/kas.AccessService/PublicKey",
+            "connect_rewrap_url": "https://platform.arkavo.net/kas.AccessService/Rewrap",
+            "public_key_url": "https://platform.arkavo.net/kas/v2/kas_public_key",
+            "rewrap_url": "https://platform.arkavo.net/kas/v2/rewrap",
+            "uri": "https://platform.arkavo.net"
+        },
+        "platform_issuer": "https://identity.arkavo.net"
+    }"#;
+
+    #[test]
+    fn deserializes_platform_well_known() {
+        let cfg: OpentdfConfiguration = serde_json::from_str(PLATFORM_WELL_KNOWN).unwrap();
+        let kas = cfg.kas.expect("kas block present");
+        assert_eq!(kas.uri, "https://platform.arkavo.net");
+        assert_eq!(kas.algorithms, vec!["ec:secp256r1", "rsa:2048"]);
+        assert_eq!(
+            kas.connect_rewrap_url.as_deref(),
+            Some("https://platform.arkavo.net/kas.AccessService/Rewrap")
+        );
+        assert_eq!(
+            kas.rewrap_url.as_deref(),
+            Some("https://platform.arkavo.net/kas/v2/rewrap")
+        );
+        let idp = cfg.idp.expect("idp block present");
+        assert_eq!(idp.issuer, "https://identity.arkavo.net");
+        assert_eq!(idp.access_token_format.as_deref(), Some("application/cwt"));
+        assert_eq!(
+            cfg.platform_issuer.as_deref(),
+            Some("https://identity.arkavo.net")
+        );
+    }
+
+    #[test]
+    fn deserializes_minimal_kas_only() {
+        let json = r#"{
+            "kas": {
+                "uri": "https://k.example.com",
+                "algorithms": [],
+                "rewrap_url": "https://k.example.com/kas/v2/rewrap",
+                "public_key_url": "https://k.example.com/kas/v2/kas_public_key"
+            }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let kas = cfg.kas.unwrap();
+        assert!(kas.connect_rewrap_url.is_none());
+        assert_eq!(
+            kas.rewrap_url.as_deref(),
+            Some("https://k.example.com/kas/v2/rewrap")
+        );
+        assert!(cfg.idp.is_none());
+    }
+}

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -6,6 +6,7 @@
 
 #![cfg(feature = "kas-client")]
 
+use opentdf_protocol::KasError;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -41,6 +42,54 @@ pub struct IdpConfig {
     pub response_types_supported: Vec<String>,
     #[serde(default)]
     pub subject_types_supported: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KasTransport {
+    /// ConnectRPC endpoints at /kas.AccessService/*
+    Connect,
+    /// Legacy REST gateway at /kas/v2/*
+    LegacyRest,
+}
+
+#[derive(Debug, Clone)]
+pub struct KasEndpoints {
+    pub rewrap_url: String,
+    pub public_key_url: String,
+    pub transport: KasTransport,
+}
+
+impl KasEndpoints {
+    /// Resolve KAS endpoints from a configuration document, preferring
+    /// ConnectRPC URLs and falling back to legacy REST when only REST is
+    /// advertised.
+    pub fn from_config(cfg: &OpentdfConfiguration) -> Result<Self, KasError> {
+        let kas = cfg.kas.as_ref().ok_or_else(|| KasError::ConfigError {
+            reason: "well-known configuration is missing a 'kas' block".to_string(),
+        })?;
+
+        if let (Some(rewrap), Some(public_key)) =
+            (&kas.connect_rewrap_url, &kas.connect_public_key_url)
+        {
+            return Ok(KasEndpoints {
+                rewrap_url: rewrap.clone(),
+                public_key_url: public_key.clone(),
+                transport: KasTransport::Connect,
+            });
+        }
+
+        if let (Some(rewrap), Some(public_key)) = (&kas.rewrap_url, &kas.public_key_url) {
+            return Ok(KasEndpoints {
+                rewrap_url: rewrap.clone(),
+                public_key_url: public_key.clone(),
+                transport: KasTransport::LegacyRest,
+            });
+        }
+
+        Err(KasError::ConfigError {
+            reason: "well-known kas block exposes neither Connect nor REST URLs".to_string(),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -114,5 +163,66 @@ mod tests {
             Some("https://k.example.com/kas/v2/rewrap")
         );
         assert!(cfg.idp.is_none());
+    }
+
+    #[test]
+    fn from_config_picks_connect_when_present() {
+        let cfg: OpentdfConfiguration = serde_json::from_str(PLATFORM_WELL_KNOWN).unwrap();
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://platform.arkavo.net/kas.AccessService/Rewrap"
+        );
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://platform.arkavo.net/kas.AccessService/PublicKey"
+        );
+        assert_eq!(endpoints.transport, KasTransport::Connect);
+    }
+
+    #[test]
+    fn from_config_falls_back_to_rest_when_connect_absent() {
+        let json = r#"{
+            "kas": {
+                "uri": "https://k.example.com",
+                "algorithms": [],
+                "rewrap_url": "https://k.example.com/kas/v2/rewrap",
+                "public_key_url": "https://k.example.com/kas/v2/kas_public_key"
+            }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(endpoints.rewrap_url, "https://k.example.com/kas/v2/rewrap");
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://k.example.com/kas/v2/kas_public_key"
+        );
+        assert_eq!(endpoints.transport, KasTransport::LegacyRest);
+    }
+
+    #[test]
+    fn from_config_errors_when_kas_block_missing() {
+        let json = r#"{ "platform_issuer": "https://example.com" }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let err = KasEndpoints::from_config(&cfg).unwrap_err();
+        match err {
+            opentdf_protocol::KasError::ConfigError { reason } => {
+                assert!(reason.contains("kas"));
+            }
+            other => panic!("expected ConfigError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_config_errors_when_urls_missing() {
+        let json = r#"{
+            "kas": { "uri": "https://k.example.com", "algorithms": [] }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        let err = KasEndpoints::from_config(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            opentdf_protocol::KasError::ConfigError { .. }
+        ));
     }
 }

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -52,6 +52,49 @@ pub enum KasTransport {
     LegacyRest,
 }
 
+impl OpentdfConfiguration {
+    /// Synthesize a configuration document pointing at a single KAS base URL
+    /// using ConnectRPC paths. Use this when you can't or don't want to fetch
+    /// `/.well-known/opentdf-configuration` (e.g., tests, deployments that
+    /// don't expose the well-known endpoint).
+    pub fn for_kas_connect(base_url: impl Into<String>) -> Self {
+        let base = base_url.into();
+        let base = base.trim_end_matches('/').to_string();
+        Self {
+            kas: Some(KasConfig {
+                uri: base.clone(),
+                algorithms: vec![],
+                public_key_url: None,
+                rewrap_url: None,
+                connect_public_key_url: Some(format!("{}/kas.AccessService/PublicKey", base)),
+                connect_rewrap_url: Some(format!("{}/kas.AccessService/Rewrap", base)),
+            }),
+            idp: None,
+            platform_issuer: None,
+        }
+    }
+
+    /// Synthesize a configuration document pointing at a single KAS base URL
+    /// using legacy REST paths. Escape hatch for deployments that haven't
+    /// migrated to ConnectRPC.
+    pub fn for_kas_legacy_rest(base_url: impl Into<String>) -> Self {
+        let base = base_url.into();
+        let base = base.trim_end_matches('/').to_string();
+        Self {
+            kas: Some(KasConfig {
+                uri: base.clone(),
+                algorithms: vec![],
+                public_key_url: Some(format!("{}/kas/v2/kas_public_key", base)),
+                rewrap_url: Some(format!("{}/kas/v2/rewrap", base)),
+                connect_public_key_url: None,
+                connect_rewrap_url: None,
+            }),
+            idp: None,
+            platform_issuer: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct KasEndpoints {
     pub rewrap_url: String,
@@ -224,5 +267,45 @@ mod tests {
             err,
             opentdf_protocol::KasError::ConfigError { .. }
         ));
+    }
+
+    #[test]
+    fn for_kas_connect_constructs_expected_urls() {
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://kas.example.com/kas.AccessService/Rewrap"
+        );
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://kas.example.com/kas.AccessService/PublicKey"
+        );
+        assert_eq!(endpoints.transport, KasTransport::Connect);
+    }
+
+    #[test]
+    fn for_kas_connect_handles_trailing_slash() {
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com/");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://kas.example.com/kas.AccessService/Rewrap"
+        );
+    }
+
+    #[test]
+    fn for_kas_legacy_rest_constructs_expected_urls() {
+        let cfg = OpentdfConfiguration::for_kas_legacy_rest("https://kas.example.com");
+        let endpoints = KasEndpoints::from_config(&cfg).unwrap();
+        assert_eq!(
+            endpoints.rewrap_url,
+            "https://kas.example.com/kas/v2/rewrap"
+        );
+        assert_eq!(
+            endpoints.public_key_url,
+            "https://kas.example.com/kas/v2/kas_public_key"
+        );
+        assert_eq!(endpoints.transport, KasTransport::LegacyRest);
     }
 }

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -135,6 +135,34 @@ impl KasEndpoints {
     }
 }
 
+/// Error envelope returned by Connect unary-JSON RPCs on non-2xx responses.
+///
+/// Codes are defined by the Connect protocol spec
+/// (canceled, unknown, invalid_argument, deadline_exceeded, not_found,
+/// already_exists, permission_denied, resource_exhausted, failed_precondition,
+/// aborted, out_of_range, unimplemented, internal, unavailable, data_loss,
+/// unauthenticated).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConnectError {
+    pub code: String,
+    pub message: String,
+}
+
+/// Attempt to parse a Connect error envelope from a response body.
+/// Returns `None` for empty bodies, non-JSON bodies, or JSON that doesn't
+/// match the Connect error shape.
+pub fn parse_connect_error(body: &str) -> Option<ConnectError> {
+    if body.is_empty() {
+        return None;
+    }
+    let parsed: ConnectError = serde_json::from_str(body).ok()?;
+    // Reject objects that happen to deserialize but lack meaningful content
+    if parsed.code.is_empty() {
+        return None;
+    }
+    Some(parsed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,5 +335,20 @@ mod tests {
             "https://kas.example.com/kas/v2/kas_public_key"
         );
         assert_eq!(endpoints.transport, KasTransport::LegacyRest);
+    }
+
+    #[test]
+    fn parse_connect_error_with_valid_body() {
+        let body = r#"{"code":"unauthenticated","message":"missing bearer token"}"#;
+        let err = parse_connect_error(body).unwrap();
+        assert_eq!(err.code, "unauthenticated");
+        assert_eq!(err.message, "missing bearer token");
+    }
+
+    #[test]
+    fn parse_connect_error_with_garbage_returns_none() {
+        assert!(parse_connect_error("not json").is_none());
+        assert!(parse_connect_error("").is_none());
+        assert!(parse_connect_error(r#"{"unrelated":"shape"}"#).is_none());
     }
 }

--- a/src/kas_discovery.rs
+++ b/src/kas_discovery.rs
@@ -106,32 +106,113 @@ impl KasEndpoints {
     /// Resolve KAS endpoints from a configuration document, preferring
     /// ConnectRPC URLs and falling back to legacy REST when only REST is
     /// advertised.
+    ///
+    /// Both resolved URLs are validated for HTTPS / scheme / SSRF constraints
+    /// (see [`validate_kas_url`]). This matters because the URLs may originate
+    /// from a remotely-fetched well-known document — a hostile document must
+    /// not be able to redirect the rewrap request (which carries the OAuth
+    /// bearer) at an internal target.
     pub fn from_config(cfg: &OpentdfConfiguration) -> Result<Self, KasError> {
         let kas = cfg.kas.as_ref().ok_or_else(|| KasError::ConfigError {
             reason: "well-known configuration is missing a 'kas' block".to_string(),
         })?;
 
-        if let (Some(rewrap), Some(public_key)) =
+        let endpoints = if let (Some(rewrap), Some(public_key)) =
             (&kas.connect_rewrap_url, &kas.connect_public_key_url)
         {
-            return Ok(KasEndpoints {
+            KasEndpoints {
                 rewrap_url: rewrap.clone(),
                 public_key_url: public_key.clone(),
                 transport: KasTransport::Connect,
-            });
-        }
-
-        if let (Some(rewrap), Some(public_key)) = (&kas.rewrap_url, &kas.public_key_url) {
-            return Ok(KasEndpoints {
+            }
+        } else if let (Some(rewrap), Some(public_key)) = (&kas.rewrap_url, &kas.public_key_url) {
+            KasEndpoints {
                 rewrap_url: rewrap.clone(),
                 public_key_url: public_key.clone(),
                 transport: KasTransport::LegacyRest,
+            }
+        } else {
+            return Err(KasError::ConfigError {
+                reason: "well-known kas block exposes neither Connect nor REST URLs".to_string(),
             });
-        }
+        };
 
-        Err(KasError::ConfigError {
-            reason: "well-known kas block exposes neither Connect nor REST URLs".to_string(),
-        })
+        validate_kas_url(&endpoints.rewrap_url)?;
+        validate_kas_url(&endpoints.public_key_url)?;
+
+        Ok(endpoints)
+    }
+}
+
+/// Validate a KAS URL for HTTPS / SSRF / scheme constraints.
+///
+/// - **Scheme**: only `http` and `https` are accepted.
+/// - **HTTPS required**: plain `http` is allowed only for loopback hosts
+///   (`localhost`, `127.0.0.0/8`, `::1`) for local development.
+/// - **SSRF protection**: private and link-local addresses are rejected,
+///   covering IPv4 (`10/8`, `172.16/12`, `192.168/16`, `169.254/16`), IPv6
+///   unique-local (`fc00::/7`) and link-local (`fe80::/10`), and IPv4-mapped
+///   IPv6 literals (e.g. `::ffff:169.254.169.254`), which are folded back to
+///   their IPv4 form before the check.
+pub fn validate_kas_url(url_str: &str) -> Result<(), KasError> {
+    use std::net::IpAddr;
+
+    let parsed = url::Url::parse(url_str)
+        .map_err(|e| KasError::InvalidUrl(format!("Failed to parse URL: {e}")))?;
+
+    match parsed.scheme() {
+        "https" => {}
+        "http" => {
+            let is_loopback = match parsed.host() {
+                Some(url::Host::Domain("localhost")) => true,
+                Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+                Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+                _ => false,
+            };
+            if !is_loopback {
+                return Err(KasError::InvalidUrl(
+                    "KAS URL must use HTTPS (HTTP only allowed for localhost)".to_string(),
+                ));
+            }
+        }
+        scheme => {
+            return Err(KasError::InvalidUrl(format!(
+                "Unsupported URL scheme '{scheme}', must be https"
+            )));
+        }
+    }
+
+    // Fold any IPv4-mapped IPv6 literal back to IPv4 so `::ffff:169.254.169.254`
+    // can't bypass the IPv4 metadata/private-range checks.
+    let ip = match parsed.host() {
+        Some(url::Host::Ipv4(v4)) => Some(IpAddr::V4(v4)),
+        Some(url::Host::Ipv6(v6)) => Some(IpAddr::V6(v6).to_canonical()),
+        _ => None,
+    };
+
+    if let Some(ip) = ip
+        && is_blocked_ip(&ip)
+    {
+        return Err(KasError::InvalidUrl(
+            "KAS URL must not target private or link-local IP addresses".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// True if `ip` is in a private or link-local range that must never be a KAS
+/// target (SSRF guard). Loopback is intentionally *not* blocked here — the
+/// scheme check above already gates loopback to HTTP-only dev use.
+fn is_blocked_ip(ip: &std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            let first = v6.segments()[0];
+            // Unique-local fc00::/7 or unicast link-local fe80::/10.
+            (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
+        }
     }
 }
 
@@ -167,6 +248,11 @@ pub fn parse_connect_error(body: &str) -> Option<ConnectError> {
 ///
 /// `platform_url` should be the platform's base URL (e.g.,
 /// `"https://platform.arkavo.net"`). A trailing slash is tolerated.
+///
+/// The request is issued on the caller-provided `http_client` and inherits its
+/// configuration. Because this function applies no timeout of its own, the
+/// caller should build the client with a `.timeout(..)` so discovery cannot
+/// hang indefinitely against an unresponsive endpoint.
 pub async fn fetch_well_known(
     platform_url: &str,
     http_client: &reqwest::Client,
@@ -374,6 +460,88 @@ mod tests {
             "https://kas.example.com/kas/v2/kas_public_key"
         );
         assert_eq!(endpoints.transport, KasTransport::LegacyRest);
+    }
+
+    #[test]
+    fn validate_kas_url_accepts_https_and_loopback_http() {
+        assert!(validate_kas_url("https://kas.example.com/kas.AccessService/Rewrap").is_ok());
+        assert!(validate_kas_url("http://localhost:8080/x").is_ok());
+        assert!(validate_kas_url("http://127.0.0.1:8080/x").is_ok());
+        assert!(validate_kas_url("http://[::1]:8080/x").is_ok());
+    }
+
+    #[test]
+    fn validate_kas_url_rejects_non_loopback_http_and_bad_scheme() {
+        assert!(matches!(
+            validate_kas_url("http://evil.com/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
+        assert!(matches!(
+            validate_kas_url("ftp://kas.example.com/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn validate_kas_url_rejects_ipv4_private_and_link_local() {
+        for url in [
+            "https://10.0.0.1/x",
+            "https://172.16.0.1/x",
+            "https://192.168.1.1/x",
+            "https://169.254.169.254/x",
+        ] {
+            assert!(
+                matches!(validate_kas_url(url), Err(KasError::InvalidUrl(_))),
+                "{url} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_kas_url_rejects_ipv6_ula_and_link_local() {
+        for url in [
+            "https://[fd00::1]/x", // unique-local fc00::/7
+            "https://[fc00::1]/x", // unique-local fc00::/7
+            "https://[fe80::1]/x", // link-local fe80::/10
+        ] {
+            assert!(
+                matches!(validate_kas_url(url), Err(KasError::InvalidUrl(_))),
+                "{url} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_kas_url_rejects_ipv4_mapped_metadata_address() {
+        // ::ffff:169.254.169.254 must fold back to IPv4 and be rejected,
+        // not slip through as an unchecked IPv6 literal.
+        assert!(matches!(
+            validate_kas_url("https://[::ffff:169.254.169.254]/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
+        assert!(matches!(
+            validate_kas_url("https://[::ffff:10.0.0.1]/x"),
+            Err(KasError::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn from_config_rejects_hostile_connect_url() {
+        // A well-known document that points the Connect rewrap URL at an
+        // internal address must be rejected at resolution time.
+        let json = r#"{
+            "kas": {
+                "uri": "https://platform.example.com",
+                "algorithms": [],
+                "connect_rewrap_url": "https://169.254.169.254/kas.AccessService/Rewrap",
+                "connect_public_key_url": "https://platform.example.com/kas.AccessService/PublicKey"
+            }
+        }"#;
+        let cfg: OpentdfConfiguration = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            KasEndpoints::from_config(&cfg),
+            Err(KasError::InvalidUrl(_))
+        ));
     }
 
     #[test]

--- a/src/kas_key.rs
+++ b/src/kas_key.rs
@@ -69,6 +69,10 @@ pub struct KasEcPublicKeyResponse {
 /// # Returns
 ///
 /// The PEM-encoded RSA public key as a String
+#[deprecated(
+    since = "0.13.0",
+    note = "Legacy /kas/v2/* REST endpoint. Use fetch_kas_public_key_connect with a URL resolved from OpentdfConfiguration or fetch_well_known()."
+)]
 #[cfg(feature = "kas-client")]
 pub async fn fetch_kas_public_key(
     kas_url: &str,
@@ -99,6 +103,36 @@ pub async fn fetch_kas_public_key(
     // Parse the JSON response
     let key_response: KasPublicKeyResponse = response.json().await?;
 
+    Ok(key_response)
+}
+
+/// Fetch the KAS public key via ConnectRPC.
+///
+/// Unlike `fetch_kas_public_key`, this expects a pre-resolved URL (typically
+/// from `KasEndpoints::public_key_url`) and POSTs an empty JSON body — the
+/// Connect protocol requires a request body even for empty message types.
+#[cfg(feature = "kas-client")]
+pub async fn fetch_kas_public_key_connect(
+    public_key_url: &str,
+    http_client: &Client,
+) -> Result<KasPublicKeyResponse, KasKeyError> {
+    let response = http_client
+        .post(public_key_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        return Err(KasKeyError::HttpError(format!(
+            "POST {} -> HTTP {}: {}",
+            public_key_url, status, error_body
+        )));
+    }
+
+    let key_response: KasPublicKeyResponse = response.json().await?;
     Ok(key_response)
 }
 
@@ -153,6 +187,10 @@ pub fn validate_rsa_public_key_pem(pem: &str) -> Result<String, KasKeyError> {
 /// # Ok(())
 /// # }
 /// ```
+#[deprecated(
+    since = "0.13.0",
+    note = "Legacy /kas/v2/* REST endpoint. Use fetch_kas_ec_public_key_connect with a URL resolved from OpentdfConfiguration or fetch_well_known()."
+)]
 #[cfg(feature = "kas-client")]
 pub async fn fetch_kas_ec_public_key(
     kas_url: &str,
@@ -186,6 +224,35 @@ pub async fn fetch_kas_ec_public_key(
     // Validate the key is actually an EC key
     validate_ec_public_key_pem(&key_response.public_key)?;
 
+    Ok(key_response)
+}
+
+/// Fetch the KAS EC public key via ConnectRPC.
+///
+/// Unlike `fetch_kas_ec_public_key`, this expects a pre-resolved URL.
+#[cfg(feature = "kas-client")]
+pub async fn fetch_kas_ec_public_key_connect(
+    public_key_url: &str,
+    http_client: &Client,
+) -> Result<KasEcPublicKeyResponse, KasKeyError> {
+    let response = http_client
+        .post(public_key_url)
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        return Err(KasKeyError::HttpError(format!(
+            "POST {} -> HTTP {}: {}",
+            public_key_url, status, error_body
+        )));
+    }
+
+    let key_response: KasEcPublicKeyResponse = response.json().await?;
+    validate_ec_public_key_pem(&key_response.public_key)?;
     Ok(key_response)
 }
 
@@ -331,6 +398,43 @@ PvJX+E+ceUD7JIZc87FvaA5OqwFUFXqJfYNU4ZE7d6ovRja8JwnErHa+7pEk6KkN
                 .starts_with("-----BEGIN PUBLIC KEY-----")
         );
         assert_eq!(response.kid, "ec:secp256r1");
+    }
+
+    #[cfg(feature = "kas-client")]
+    #[tokio::test]
+    async fn test_fetch_kas_public_key_connect_against_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/kas.AccessService/PublicKey")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"publicKey":"-----BEGIN PUBLIC KEY-----\ntestkey\n-----END PUBLIC KEY-----\n","kid":"r1"}"#)
+            .create_async()
+            .await;
+
+        let url = format!("{}/kas.AccessService/PublicKey", server.url());
+        let http = reqwest::Client::new();
+        let resp = fetch_kas_public_key_connect(&url, &http).await.unwrap();
+        assert!(resp.public_key.starts_with("-----BEGIN PUBLIC KEY-----"));
+        assert_eq!(resp.kid, "r1");
+    }
+
+    #[cfg(feature = "kas-client")]
+    #[tokio::test]
+    async fn test_fetch_kas_ec_public_key_connect_against_mock() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("POST", "/kas.AccessService/PublicKey")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"publicKey":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/shJbT/RbVUkgV+/5m+KPblr5ZXH\nHU+2K5VytEsGQJJ0fxiksZXDC7twCPAXZgE3LOvORGqbQriKe/nM4iqIuA==\n-----END PUBLIC KEY-----\n","kid":"ec:secp256r1"}"#)
+            .create_async()
+            .await;
+
+        let url = format!("{}/kas.AccessService/PublicKey", server.url());
+        let http = reqwest::Client::new();
+        let resp = fetch_kas_ec_public_key_connect(&url, &http).await.unwrap();
+        assert_eq!(resp.kid, "ec:secp256r1");
     }
 
     #[cfg(feature = "kas-client")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ mod tdf;
 pub mod kas;
 
 #[cfg(feature = "kas-client")]
+pub mod kas_discovery;
+
+#[cfg(feature = "kas-client")]
 pub mod kas_key;
 
 // JSON-RPC integration (ZTDF-JSON format)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,9 +123,11 @@ pub use fqn::{AttributeFqn, FqnValidationRules, NamespaceRegistry};
 pub use kas::{KasClient, KeyType};
 
 #[cfg(feature = "kas-client")]
+#[allow(deprecated)]
 pub use kas_key::{
     KasEcPublicKeyResponse, KasKeyError, KasPublicKeyResponse, fetch_kas_ec_public_key,
-    fetch_kas_public_key, validate_ec_public_key_pem, validate_rsa_public_key_pem,
+    fetch_kas_ec_public_key_connect, fetch_kas_public_key, fetch_kas_public_key_connect,
+    validate_ec_public_key_pem, validate_rsa_public_key_pem,
 };
 
 #[cfg(feature = "kas-client")]

--- a/src/tdf.rs
+++ b/src/tdf.rs
@@ -87,7 +87,10 @@ impl Tdf {
     /// ```no_run
     /// # use opentdf::{Tdf, kas::KasClient};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let kas_client = KasClient::new("https://kas.example.com", "token")?;
+    /// let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+    ///     "https://kas.example.com",
+    /// );
+    /// let kas_client = KasClient::new(&config, "token")?;
     /// let tdf_data = std::fs::read("encrypted.tdf")?;
     /// let plaintext = Tdf::decrypt(tdf_data)
     ///     .kas_client(kas_client)
@@ -110,7 +113,10 @@ impl Tdf {
     /// ```no_run
     /// # use opentdf::{Tdf, kas::KasClient};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let kas_client = KasClient::new("https://kas.example.com", "token")?;
+    /// let config = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(
+    ///     "https://kas.example.com",
+    /// );
+    /// let kas_client = KasClient::new(&config, "token")?;
     /// let plaintext = Tdf::decrypt_file("encrypted.tdf")
     ///     .kas_client(kas_client)
     ///     .to_bytes()

--- a/tests/kas_integration.rs
+++ b/tests/kas_integration.rs
@@ -62,8 +62,8 @@ mod kas_tests {
         println!("Testing KAS rewrap against: {}", kas_url);
 
         // Create KAS client
-        let _kas_client =
-            KasClient::new(&kas_url, &oauth_token).expect("Failed to create KAS client");
+        let cfg = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(&kas_url);
+        let _kas_client = KasClient::new(&cfg, &oauth_token).expect("Failed to create KAS client");
 
         // Create a simple TDF for testing
         let plaintext = b"Hello from KAS integration test!";
@@ -115,8 +115,8 @@ mod kas_tests {
 
         println!("Testing decryption of: {}", test_tdf_path);
 
-        let kas_client =
-            KasClient::new(&kas_url, &oauth_token).expect("Failed to create KAS client");
+        let cfg = opentdf::kas_discovery::OpentdfConfiguration::for_kas_connect(&kas_url);
+        let kas_client = KasClient::new(&cfg, &oauth_token).expect("Failed to create KAS client");
 
         // Open and decrypt the TDF
         match TdfArchive::open_and_decrypt(test_tdf_path, &kas_client).await {

--- a/tests/kas_integration.rs
+++ b/tests/kas_integration.rs
@@ -169,6 +169,7 @@ mod kas_tests {
         // and we'd use KAS to unwrap it for decryption
     }
 
+    #[allow(deprecated)]
     #[tokio::test]
     #[ignore] // Requires KAS server
     async fn test_fetch_kas_ec_public_key() {

--- a/tests/kas_mock.rs
+++ b/tests/kas_mock.rs
@@ -73,7 +73,7 @@ mod kas_mock_tests {
 
         // Create a mock endpoint that validates the request format
         let mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .match_header("Authorization", "Bearer mock-token")
             .match_header("Content-Type", "application/json")
             .match_body(mockito::Matcher::Regex(r#".*"signedRequestToken":"eyJ.*"#.to_string()))
@@ -89,7 +89,7 @@ mod kas_mock_tests {
         let client = KasClient::new(&kas_url, "mock-token").unwrap();
 
         // Note: manifest URL should match what's in key_access[0].url
-        // The client will append /kas/v2/rewrap to its base_url
+        // The client will append /kas.AccessService/Rewrap to its base_url
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
         // This will fail at unwrap_key stage but validates request format
@@ -107,7 +107,7 @@ mod kas_mock_tests {
         let mut server = Server::new_async().await;
 
         let _mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .with_status(401)
             .with_header("content-type", "application/json")
             .with_body(r#"{"error": "Unauthorized"}"#)
@@ -132,11 +132,36 @@ mod kas_mock_tests {
     }
 
     #[tokio::test]
+    async fn test_kas_connect_401_envelope_surfaced_in_error() {
+        let mut server = Server::new_async().await;
+
+        let _mock = server
+            .mock("POST", "/kas.AccessService/Rewrap")
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"code":"unauthenticated","message":"missing bearer token"}"#)
+            .create();
+
+        let kas_url = server.url();
+        let client = KasClient::new(&kas_url, "bad-token").unwrap();
+        let manifest = create_test_manifest_with_policy(kas_url.clone());
+
+        let result = client.rewrap_standard_tdf(&manifest).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unauthenticated") || msg.contains("missing bearer token"),
+            "expected Connect error code/message in error string, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_kas_access_denied() {
         let mut server = Server::new_async().await;
 
         let _mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .with_status(403)
             .with_header("content-type", "application/json")
             .with_body(r#"{"error": "Access denied: insufficient permissions"}"#)
@@ -163,7 +188,7 @@ mod kas_mock_tests {
         let mut server = Server::new_async().await;
 
         let _mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .with_status(500)
             .with_header("content-type", "application/json")
             .with_body(r#"{"error": "Internal server error"}"#)
@@ -190,7 +215,7 @@ mod kas_mock_tests {
         let mut server = Server::new_async().await;
 
         let _mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"invalid": "response"}"#)
@@ -281,7 +306,7 @@ mod kas_mock_tests {
         let mut server = Server::new_async().await;
 
         let _mock = server
-            .mock("POST", "/kas/v2/rewrap")
+            .mock("POST", "/kas.AccessService/Rewrap")
             .match_header("Authorization", "Bearer test-token")
             .match_body(mockito::Matcher::Regex(
                 r#""signedRequestToken":"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+""#

--- a/tests/kas_mock.rs
+++ b/tests/kas_mock.rs
@@ -9,6 +9,7 @@ mod kas_mock_tests {
     use opentdf::{
         TdfManifest,
         kas::{KasClient, KeyType},
+        kas_discovery::OpentdfConfiguration,
         manifest::TdfManifestExt,
     };
 
@@ -63,7 +64,8 @@ mod kas_mock_tests {
 
     #[tokio::test]
     async fn test_kas_client_creation() {
-        let client = KasClient::new("https://kas.example.com", "mock-token");
+        let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
+        let client = KasClient::new(&cfg, "mock-token");
         assert!(client.is_ok(), "KAS client creation should succeed");
     }
 
@@ -86,10 +88,10 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "mock-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "mock-token").unwrap();
 
         // Note: manifest URL should match what's in key_access[0].url
-        // The client will append /kas.AccessService/Rewrap to its base_url
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
         // This will fail at unwrap_key stage but validates request format
@@ -114,7 +116,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "invalid-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "invalid-token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
@@ -143,7 +146,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "bad-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "bad-token").unwrap();
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
         let result = client.rewrap_standard_tdf(&manifest).await;
@@ -168,7 +172,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "valid-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "valid-token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
@@ -195,7 +200,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "valid-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "valid-token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
@@ -222,7 +228,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "valid-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "valid-token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 
@@ -241,7 +248,8 @@ mod kas_mock_tests {
     async fn test_kas_network_timeout() {
         // Mock server that never responds (simulates timeout)
         let kas_url = "https://192.0.2.1:9999"; // TEST-NET address, should timeout
-        let client = KasClient::new(kas_url, "token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(kas_url);
+        let client = KasClient::new(&cfg, "token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.to_string());
 
@@ -318,7 +326,8 @@ mod kas_mock_tests {
             .create();
 
         let kas_url = server.url();
-        let client = KasClient::new(&kas_url, "test-token").unwrap();
+        let cfg = OpentdfConfiguration::for_kas_connect(&kas_url);
+        let client = KasClient::new(&cfg, "test-token").unwrap();
 
         let manifest = create_test_manifest_with_policy(kas_url.clone());
 

--- a/tests/platform_integration.rs
+++ b/tests/platform_integration.rs
@@ -260,12 +260,19 @@ async fn connect_rewrap_fails_with_fake_bearer_returns_401() -> Result<(), Box<d
             println!("✓ Connect rewrap returned AccessDenied: {reason}");
         }
         KasError::HttpError { status, message } => {
-            // Acceptable: a generic HTTP error proves we hit Connect, not REST.
-            println!("✓ Connect rewrap returned HTTP {status}: {message}");
+            // A 404 would mean the Connect rewrap path does not exist on the
+            // platform — that would NOT prove Connect plumbing, so reject it
+            // explicitly. Any other 4xx/5xx means the Connect endpoint received
+            // and rejected our (deliberately unauthenticated) request.
+            assert_ne!(
+                *status, 404,
+                "got HTTP 404 — Connect rewrap path missing, plumbing NOT proven: {message}"
+            );
             assert!(
                 *status >= 400 && *status < 600,
                 "expected 4xx/5xx, got {status}"
             );
+            println!("✓ Connect rewrap returned HTTP {status}: {message}");
         }
         other => panic!("unexpected error variant: {other:?}"),
     }

--- a/tests/platform_integration.rs
+++ b/tests/platform_integration.rs
@@ -167,3 +167,107 @@ async fn test_kas_rewrap_protocol() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// ConnectRPC migration verification (#85)
+//
+// These tests run against the real Arkavo platform and document the milestone
+// state of the Connect transport. They are #[ignore]d by default; opt in with:
+//
+//   cargo test --test platform_integration --all-features -- --ignored connect
+//
+// or, if KAS_INTEGRATION_TESTS=1 is set, the user can run them by name.
+// ---------------------------------------------------------------------------
+
+const ARKAVO_PLATFORM: &str = "https://platform.arkavo.net";
+
+#[tokio::test]
+#[ignore]
+async fn connect_well_known_endpoint_returns_kas_config() -> Result<(), Box<dyn Error>> {
+    use opentdf::kas_discovery::fetch_well_known;
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    let kas = cfg.kas.expect("kas block should be present");
+    assert!(
+        kas.connect_rewrap_url.is_some(),
+        "platform should advertise connect_rewrap_url"
+    );
+    assert!(
+        kas.connect_public_key_url.is_some(),
+        "platform should advertise connect_public_key_url"
+    );
+    assert!(
+        kas.rewrap_url.is_some(),
+        "platform also exposes legacy REST rewrap_url (transitional)"
+    );
+    println!("✓ well-known reports both Connect and REST URLs");
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn connect_public_key_returns_pem() -> Result<(), Box<dyn Error>> {
+    use opentdf::kas_discovery::{KasEndpoints, fetch_well_known};
+    use opentdf::kas_key::fetch_kas_public_key_connect;
+
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    let endpoints = KasEndpoints::from_config(&cfg)?;
+    let resp = fetch_kas_public_key_connect(&endpoints.public_key_url, &http).await?;
+    assert!(
+        resp.public_key.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "expected PEM, got: {}",
+        resp.public_key
+    );
+    assert!(!resp.kid.is_empty(), "kid should be populated");
+    println!(
+        "✓ Connect PublicKey returned kid={} ({} bytes PEM)",
+        resp.kid,
+        resp.public_key.len()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn connect_rewrap_fails_with_fake_bearer_returns_401() -> Result<(), Box<dyn Error>> {
+    use opentdf::TdfManifest;
+    use opentdf::kas::KasClient;
+    use opentdf::kas_discovery::fetch_well_known;
+    use opentdf_protocol::KasError;
+
+    let http = reqwest::Client::new();
+    let cfg = fetch_well_known(ARKAVO_PLATFORM, &http).await?;
+    // Pass a syntactically-plausible bearer that the platform will reject.
+    let client = KasClient::new(&cfg, "eyJhbGciOiJub25lIn0.e30.")?;
+
+    // Build a minimal manifest with a real policy UUID so the client can
+    // serialise the rewrap request and actually reach the platform.
+    let mut manifest = TdfManifest::new("0.payload".to_string(), ARKAVO_PLATFORM.to_string());
+    manifest.set_policy_raw(r#"{"uuid":"00000000-0000-0000-0000-000000000000"}"#);
+    let result = client.rewrap_standard_tdf(&manifest).await;
+
+    let err = result.expect_err("rewrap should fail without valid auth");
+    match &err {
+        KasError::AuthenticationFailed { reason } => {
+            // Connect 'unauthenticated' code should surface in the reason string
+            // when the platform returns a Connect error envelope.
+            println!("✓ Connect rewrap returned AuthenticationFailed: {reason}");
+        }
+        KasError::AccessDenied { reason, .. } => {
+            // Some Connect implementations may return permission_denied (403)
+            // when the request is malformed.
+            println!("✓ Connect rewrap returned AccessDenied: {reason}");
+        }
+        KasError::HttpError { status, message } => {
+            // Acceptable: a generic HTTP error proves we hit Connect, not REST.
+            println!("✓ Connect rewrap returned HTTP {status}: {message}");
+            assert!(
+                *status >= 400 && *status < 600,
+                "expected 4xx/5xx, got {status}"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Switches the native KAS client transport from `/kas/v2/*` REST to `/kas.AccessService/*` ConnectRPC, hand-rolled JSON envelope (no `prost`/`tonic` codegen, zero new deps).
- Adds `src/kas_discovery.rs`: `OpentdfConfiguration` deserialization for `/.well-known/opentdf-configuration`, `KasEndpoints::from_config` with Connect-preferred / REST-fallback URL resolution, `fetch_well_known` async discovery, `parse_connect_error` envelope parser, plus `OpentdfConfiguration::for_kas_connect` / `for_kas_legacy_rest` direct builders.
- `KasClient::new` now takes `&OpentdfConfiguration` (synchronous; breaking change — `0.12.0` → `0.13.0`). Migrated all in-repo callers (tests, examples, doc comments) in the same commit as the signature change.
- `fetch_kas_public_key_connect` / `fetch_kas_ec_public_key_connect` siblings added; REST variants marked `#[deprecated(since = "0.13.0")]`.
- `examples/mock_kas_server.rs` gets ConnectRPC routes alongside legacy REST (multi-profile mock).
- Live `#[ignore]`d integration tests against `https://platform.arkavo.net` verify well-known fetch, Connect `PublicKey`, and Connect `Rewrap` (expected 401 with fake bearer — proves end-to-end transport).

Closes #85.

## Migration

```rust
// before
let client = KasClient::new("https://kas.example.com", token)?;

// after — direct
let cfg = OpentdfConfiguration::for_kas_connect("https://kas.example.com");
let client = KasClient::new(&cfg, token)?;

// after — with discovery
let cfg = fetch_well_known("https://platform.arkavo.net", &http).await?;
let client = KasClient::new(&cfg, token)?;
```

The OAuth bearer is an opaque passthrough — pass a JWT or a base64url-encoded CWT; the server decides validation.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 127 unit tests + 26 doctests + integration tests pass
- [x] `RUSTFLAGS="-D warnings" cargo build --all-features` clean
- [x] `cargo build --examples --all-features` clean
- [x] Mock 401 Connect error envelope test passes
- [x] Live tests against `platform.arkavo.net`:
  - [x] `connect_well_known_endpoint_returns_kas_config`
  - [x] `connect_public_key_returns_pem`
  - [x] `connect_rewrap_fails_with_fake_bearer_returns_401`

Run live tests manually: `cargo test --test platform_integration --all-features -- --ignored connect`

## Caveats for reviewers

- `platform.arkavo.net` currently exposes **both** REST and ConnectRPC. This PR prepares for REST removal; it does not depend on REST being already gone.
- WASM mirror, OIDC auth provider (#46), and client-side CWT verification are explicit follow-ups — not in scope here.

## Design and plan docs

- Spec: `docs/superpowers/specs/2026-05-28-connectrpc-kas-migration-design.md`
- Plan: `docs/superpowers/plans/2026-05-28-connectrpc-kas-migration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Security:**
  - Tightened SSRF protection by explicitly blocking unspecified IP addresses (`0.0.0.0` and `::`) in `validate_kas_url`.
- **Refactoring:**
  - Removed deprecated `base_url` field from `KasClient` to ensure cleaner configuration handling.

<sub>This will update automatically on new commits.</sub>