### PR TITLE
chore(release): 0.14.0 Stage-1 KAS xtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.14.0] — 2026-07-12
+
+### Added
+
+- **Stage-1 community xtest KAS path** for `examples/xtest_cli` ([#87](https://github.com/arkavo-org/opentdf-rs/pull/87)):
+  - Encrypt ZIP/Base TDF via Connect PublicKey + RSA-OAEP wrap (`kid`)
+  - Decrypt via client-credentials OAuth + `KasClient::rewrap_standard_tdf`
+  - Env contract: `CLIENTID` / `CLIENTSECRET` / `PLATFORMURL` / `KASURL` / `TOKENENDPOINT`
+  - Honest `supports` map: `hexless`, `connectrpc`, `kas-rewrap`; exit `2` for unknown features
+  - Manifest `schemaVersion` / `tdf_spec_version` **4.3.0** (go@latest hexless Stage-1)
+
+### Fixed
+
+- Standard TDF **RSA rewrap** no longer requires `sessionPublicKey` (EC-only field); RSA path returns the DEK encrypted to the client RSA key ([#87](https://github.com/arkavo-org/opentdf-rs/pull/87))
+
+### Notes
+
+- This is the first release that passes community Stage-1 (`rust` ↔ `go@latest`, Base TDF) in [arkavo-org/opentdf-tests](https://github.com/arkavo-org/opentdf-tests).
+- GitHub “latest” before this release was **0.13.0**, which lacked Stage-1 `supports hexless` / KAS CLI wiring.
+
 ## [0.13.0] — 2026-05-28
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 
 [dependencies]
 # New modular crates
-opentdf-protocol = { path = "crates/protocol", version = "0.13.0" }
-opentdf-crypto = { path = "crates/crypto", version = "0.13.0", default-features = false }
+opentdf-protocol = { path = "crates/protocol", version = "0.14.0" }
+opentdf-crypto = { path = "crates/crypto", version = "0.14.0", default-features = false }
 
 # Core dependencies (using workspace versions)
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
@@ -68,7 +68,7 @@ ciborium = "0.2"
 members = ["crates/protocol", "crates/crypto", "crates/kas", "crates/wasm"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 
 [workspace.dependencies]
 # Core serialization

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -36,7 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 # Protocol types (for NanoTDF)
-opentdf-protocol = { path = "../protocol", version = "0.13.0" }
+opentdf-protocol = { path = "../protocol", version = "0.14.0" }
 
 # KAS feature dependencies (EC, HKDF)
 p256 = { workspace = true, optional = true }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -26,8 +26,8 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-opentdf = { path = "../..", version = "0.13.0", default-features = false }
-opentdf-protocol = { path = "../protocol", version = "0.13.0" }
+opentdf = { path = "../..", version = "0.14.0", default-features = false }
+opentdf-protocol = { path = "../protocol", version = "0.14.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde.workspace = true


### PR DESCRIPTION
## Summary

Cut **0.14.0** so GitHub `latest` includes Stage-1 community xtest (currently only on `main` after #87).

### Included since 0.13.0

- [#87](https://github.com/arkavo-org/opentdf-rs/pull/87) Stage-1 `xtest_cli` KAS RSA wrap encrypt + rewrap decrypt
- Honest `supports hexless` / `connectrpc`
- RSA rewrap without `sessionPublicKey`; manifest schema **4.3.0**

### Release mechanics

Push to `main` with `Cargo.toml` / lock / src paths triggers [Release](.github/workflows/release.yaml):
1. Build/test WASM
2. Tag `0.14.0` from workspace version
3. GitHub Release + npm `@arkavo-org/opentdf-wasm@0.14.0`

### Follow-up

- Flip [opentdf-tests](https://github.com/arkavo-org/opentdf-tests) `rust-ref` default from `main` → `latest`

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Release workflow creates tag `0.14.0` and marks it Latest
- [ ] `gh api repos/arkavo-org/opentdf-rs/releases/latest --jq .tag_name` → `0.14.0`