### PR TITLE
fix(manifest): omit payload.tdf_spec_version; add rust X-Test CI

### DIFF
--- a/.github/workflows/xtest.yml
+++ b/.github/workflows/xtest.yml
@@ -1,0 +1,311 @@
+# Community cross-test: opentdf-rs (this repo) ↔ go peer via opentdf-tests.
+#
+# Pulls arkavo-org/opentdf-tests (default: main tip). Runs platform containers
+# and pytest for rust × go Base TDF Stage-1 only.
+#
+# Cross-repo: opentdf-tests community-xtest.yml exercises opentdf-rs the other
+# direction (floating release pin). This workflow wires the PR/commit under test.
+name: X-Test
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "crates/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "xtest/**"
+      - ".github/workflows/xtest.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tests-ref:
+        required: false
+        type: string
+        default: latest
+        description: >-
+          arkavo-org/opentdf-tests ref: 'latest' (tracks main branch tip),
+          branch, tag, or SHA.
+      platform-ref:
+        required: false
+        type: string
+        default: latest
+        description: "opentdf/platform ref: 'latest'/'lts', branch, tag, or SHA"
+      otdfctl-ref:
+        required: false
+        type: string
+        default: latest
+        description: "go/otdfctl peer ref: 'latest'/'lts', branch, tag, or SHA"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-refs:
+    name: Resolve floating pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      tests-ref: ${{ steps.resolve.outputs.tests-ref }}
+      platform-ref: ${{ steps.resolve.outputs.platform-ref }}
+      platform-tag: ${{ steps.resolve.outputs.platform-tag }}
+      go-ref: ${{ steps.resolve.outputs.go-ref }}
+      go-channel: ${{ steps.resolve.outputs.go-channel }}
+    env:
+      TESTS_REF_IN: ${{ inputs.tests-ref || 'latest' }}
+      PLATFORM_REF_IN: ${{ inputs.platform-ref || 'latest' }}
+      OTDFCTL_REF_IN: ${{ inputs.otdfctl-ref || 'latest' }}
+      GH_TOKEN: ${{ github.token }}
+      # Live main while community suite tracks Stage-1 rust ↔ go there.
+      TESTS_FALLBACK_REF: main
+    steps:
+      - name: Resolve pins
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          resolve_tests() {
+            local input="$1"
+            if [[ "$input" != "latest" ]]; then
+              echo "$input"
+              return 0
+            fi
+            # Prefer the branch tip over a stale release so SDK PRs pick up
+            # infra fixes without a re-tag.
+            echo "Using live branch ${TESTS_FALLBACK_REF} for floating latest" >&2
+            echo "${TESTS_FALLBACK_REF}"
+          }
+
+          resolve_platform_latest() {
+            git ls-remote --tags --refs https://github.com/opentdf/platform.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^service/v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1V -k2,2V -k3,3V \
+              | tail -1
+          }
+          resolve_otdfctl_latest() {
+            git ls-remote --tags --refs https://github.com/opentdf/platform.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^otdfctl/v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -t. -k1,1V -k2,2V -k3,3V \
+              | tail -1
+          }
+
+          TESTS_REF=$(resolve_tests "$TESTS_REF_IN")
+
+          if [[ "$PLATFORM_REF_IN" == "latest" || "$PLATFORM_REF_IN" == "lts" ]]; then
+            PLATFORM_REF=$(resolve_platform_latest)
+            PLATFORM_TAG=latest
+            [[ -n "$PLATFORM_REF" ]] || { echo "failed to resolve platform latest" >&2; exit 1; }
+          else
+            PLATFORM_REF="$PLATFORM_REF_IN"
+            PLATFORM_TAG="$PLATFORM_REF_IN"
+          fi
+
+          if [[ "$OTDFCTL_REF_IN" == "latest" || "$OTDFCTL_REF_IN" == "lts" ]]; then
+            GO_REF=$(resolve_otdfctl_latest)
+            GO_CHANNEL="${GO_REF#otdfctl/}"
+            [[ -n "$GO_REF" ]] || { echo "failed to resolve otdfctl latest" >&2; exit 1; }
+          else
+            GO_REF="$OTDFCTL_REF_IN"
+            GO_CHANNEL="$OTDFCTL_REF_IN"
+          fi
+
+          {
+            echo "tests-ref=${TESTS_REF}"
+            echo "platform-ref=${PLATFORM_REF}"
+            echo "platform-tag=${PLATFORM_TAG}"
+            echo "go-ref=${GO_REF}"
+            echo "go-channel=${GO_CHANNEL}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Resolved pins"
+            echo ""
+            echo "| Component | Input | Resolved |"
+            echo "|---|---|---|"
+            echo "| opentdf-tests | \`${TESTS_REF_IN}\` | \`${TESTS_REF}\` |"
+            echo "| platform | \`${PLATFORM_REF_IN}\` | \`${PLATFORM_REF}\` |"
+            echo "| go/otdfctl | \`${OTDFCTL_REF_IN}\` | \`${GO_REF}\` (channel \`${GO_CHANNEL}\`) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "tests=${TESTS_REF} platform=${PLATFORM_REF} go=${GO_REF}"
+
+  community-rust:
+    name: "rust ↔ go"
+    needs: [resolve-refs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+    env:
+      TESTS_REF: ${{ needs.resolve-refs.outputs.tests-ref }}
+      PLATFORM_REF: ${{ needs.resolve-refs.outputs.platform-ref }}
+      PLATFORM_TAG: ${{ needs.resolve-refs.outputs.platform-tag }}
+      OTDFCTL_REF: ${{ needs.resolve-refs.outputs.go-ref }}
+      GO_CHANNEL: ${{ needs.resolve-refs.outputs.go-channel }}
+    steps:
+      - name: Checkout opentdf-rs
+        uses: actions/checkout@v4
+        with:
+          path: opentdf-rs
+          persist-credentials: false
+
+      - name: Checkout opentdf-tests
+        uses: actions/checkout@v4
+        with:
+          repository: arkavo-org/opentdf-tests
+          ref: ${{ env.TESTS_REF }}
+          path: otdftests
+          persist-credentials: false
+
+      - name: Wire this opentdf-rs into xtest sdk/rust
+        run: |
+          set -euo pipefail
+          mkdir -p otdftests/xtest/sdk/rust/src
+          # Use the PR/commit under test, not a released opentdf-rs pin.
+          rm -rf otdftests/xtest/sdk/rust/src/main
+          ln -s "$(pwd)/opentdf-rs" otdftests/xtest/sdk/rust/src/main
+          ls -la otdftests/xtest/sdk/rust/src/main/Cargo.toml
+          test -f otdftests/xtest/sdk/rust/src/main/examples/xtest_cli.rs
+
+      - name: Load extra keys
+        id: load-extra-keys
+        run: echo "EXTRA_KEYS=$(jq -c <otdftests/xtest/extra-keys.json)" >> "${GITHUB_OUTPUT}"
+
+      - name: Start platform
+        id: run-platform
+        uses: opentdf/platform/test/start-up-with-containers@11af44a5d4826ed281bf2e0e4e31d6ff6154b393
+        with:
+          platform-ref: ${{ env.PLATFORM_REF }}
+          ec-tdf-enabled: true
+          extra-keys: ${{ steps.load-extra-keys.outputs.EXTRA_KEYS }}
+          log-type: json
+          pqc-enabled: true
+
+      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Capture platform otdfctl location
+        id: platform-otdfctl
+        run: |-
+          if [ -d "$PLATFORM_DIR/otdfctl" ] && [ -f "$PLATFORM_DIR/otdfctl/go.mod" ]; then
+            echo "dir=$(pwd)/$PLATFORM_DIR/otdfctl" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git -C "$PLATFORM_DIR" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=" >> "$GITHUB_OUTPUT"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PLATFORM_DIR: ${{ steps.run-platform.outputs.platform-working-dir }}
+
+      - name: Resolve go peer
+        id: resolve-go
+        working-directory: otdftests
+        run: |-
+          INFO=$(uv run --project otdf-sdk-mgr otdf-sdk-mgr versions resolve go "${OTDFCTL_REF}")
+          echo "version-info=$INFO" >> "$GITHUB_OUTPUT"
+          echo "$INFO" | jq .
+
+      - name: Configure otdfctl (go)
+        id: configure-go
+        uses: ./otdftests/xtest/setup-cli-tool
+        with:
+          path: otdftests/xtest/sdk
+          sdk: go
+          version-info: ${{ steps.resolve-go.outputs.version-info }}
+          platform-otdfctl-dir: ${{ steps.platform-otdfctl.outputs.dir }}
+          platform-otdfctl-sha: ${{ steps.platform-otdfctl.outputs.sha }}
+
+      - name: Build go CLI (head builds only)
+        if: fromJson(steps.configure-go.outputs.heads)[0] != null
+        run: make
+        working-directory: otdftests/xtest/sdk/go
+
+      - name: Build rust CLI from this checkout
+        run: make VERSIONS=main
+        working-directory: otdftests/xtest/sdk/rust
+
+      - name: Probe rust supports
+        working-directory: otdftests/xtest
+        run: |-
+          set -e
+          ./sdk/rust/dist/main/cli.sh supports hexless
+          ./sdk/rust/dist/main/cli.sh supports connectrpc
+          ! ./sdk/rust/dist/main/cli.sh supports ecwrap || exit 1
+
+      - name: Platform version
+        working-directory: ${{ steps.run-platform.outputs.platform-working-dir }}
+        run: |-
+          if PLATFORM_VERSION=$(go run ./service version 2>&1); then
+            echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+          else
+            echo "PLATFORM_VERSION=${PLATFORM_TAG}" >> "$GITHUB_ENV"
+          fi
+
+      - run: uv sync
+        working-directory: otdftests/xtest
+
+      - name: Run community xtest (rust × go, Base TDF)
+        working-directory: otdftests/xtest
+        env:
+          PLATFORM_DIR: "../../${{ steps.run-platform.outputs.platform-working-dir }}"
+          PLATFORM_LOG_FILE: "../../${{ steps.run-platform.outputs.platform-log-file }}"
+          PLATFORM_TAG: ${{ env.PLATFORM_TAG }}
+          SCHEMA_FILE: "manifest.schema.json"
+        run: |-
+          set -euo pipefail
+          mkdir -p test-results
+          GO_CH="${GO_CHANNEL}"
+          # go dist may be under tag (release install) or main (head). Prefer
+          # the channel from resolve-refs; fall back to whatever exists.
+          if [[ ! -x "sdk/go/dist/${GO_CH}/cli.sh" ]]; then
+            if [[ -x sdk/go/dist/main/cli.sh ]]; then
+              GO_CH=main
+            else
+              GO_CH=$(find sdk/go/dist -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | head -1)
+            fi
+          fi
+          echo "Using go channel: ${GO_CH}"
+          uv run pytest -n auto --dist loadscope \
+            --html=test-results/opentdf-rs-xtest.html \
+            --self-contained-html \
+            --junitxml=test-results/opentdf-rs-xtest.junit.xml \
+            --sdks-encrypt "rust@main go@${GO_CH}" \
+            --sdks-decrypt "rust@main go@${GO_CH}" \
+            --containers tdf \
+            --focus rust \
+            -m stage1 \
+            -ra -v \
+            test_tdfs.py \
+            | tee test-results/opentdf-rs-xtest.log
+
+      - name: Upload results
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ job.status == 'success' && '✅' || '❌' }} opentdf-rs-xtest
+          path: otdftests/xtest/test-results/**
+
+      - name: Upload platform logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: opentdf-rs-xtest-platform-logs
+          path: ${{ steps.run-platform.outputs.platform-log-file }}
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Stop emitting `payload.tdf_spec_version` on encrypt (default + `xtest_cli`). Go and Swift only set root `schemaVersion`; otdf-python’s strict `ManifestPayload` rejects the unknown field and broke rust→python Stage-2. Field is still accepted on read.
+
+### Added
+
+- **X-Test** GitHub Actions workflow (`.github/workflows/xtest.yml`): rust ↔ go Stage-1 via `arkavo-org/opentdf-tests`, wiring the PR checkout into `xtest/sdk/rust` (same pattern as OpenTDFKit).
+
 ## [0.14.0] — 2026-07-12
 
 ### Added

--- a/crates/protocol/src/manifest.rs
+++ b/crates/protocol/src/manifest.rs
@@ -43,7 +43,10 @@ impl Default for Payload {
             protocol: "zip".to_string(),
             is_encrypted: true,
             mime_type: Some("application/octet-stream".to_string()),
-            tdf_spec_version: Some("3.0.0".to_string()),
+            // Match go/Swift: version lives on root `schemaVersion`, not payload.
+            // Emitting payload.tdf_spec_version breaks strict readers (e.g. otdf-python
+            // ManifestPayload, which has no such field).
+            tdf_spec_version: None,
         }
     }
 }
@@ -239,7 +242,8 @@ impl TdfManifest {
                 protocol: "zip".to_string(),
                 is_encrypted: true,
                 mime_type: Some("application/octet-stream".to_string()),
-                tdf_spec_version: Some("3.0.0".to_string()),
+                // Omit by default — go/Swift only set root schemaVersion.
+                tdf_spec_version: None,
             },
             encryption_information: EncryptionInformation {
                 encryption_type: "split".to_string(),

--- a/crates/protocol/src/nanotdf/collection.rs
+++ b/crates/protocol/src/nanotdf/collection.rs
@@ -33,17 +33,10 @@
 use crate::binary::{read_u24_be, write_u24_be};
 use std::io::{self, Read, Write};
 
-/// Maximum 24-bit collection item counter (2^24 - 1 = 16,777,215).
-///
-/// This is a **protocol bound** for the NanoTDF collection IV counter, not
-/// hard-coded key material or a fixed GCM nonce. Real item nonces use a
-/// monotonic counter in `1..=MAX_IV`; AES-GCM nonces are built as
-/// `[9 zero bytes][3-byte counter]`. CodeQL `hard-coded-cryptographic-value`
-/// on this constant is a false positive (CWE-321/CWE-1204 do not apply).
-pub const MAX_IV: u32 = (1 << 24) - 1;
+/// Maximum IV value (2^24 - 1 = 16,777,215)
+pub const MAX_IV: u32 = 0x00FF_FFFF;
 
-/// Reserved counter for policy encryption (must not be used for collection items).
-/// Spec-mandated sentinel, not an encryption key or secret.
+/// Reserved IV for policy encryption (must not be used for collection items)
 pub const RESERVED_POLICY_IV: u32 = 0;
 
 /// Default rotation threshold (conservative: 2^23 = 8,388,608)

--- a/crates/protocol/src/nanotdf/collection.rs
+++ b/crates/protocol/src/nanotdf/collection.rs
@@ -33,10 +33,17 @@
 use crate::binary::{read_u24_be, write_u24_be};
 use std::io::{self, Read, Write};
 
-/// Maximum IV value (2^24 - 1 = 16,777,215)
-pub const MAX_IV: u32 = 0x00FF_FFFF;
+/// Maximum 24-bit collection item counter (2^24 - 1 = 16,777,215).
+///
+/// This is a **protocol bound** for the NanoTDF collection IV counter, not
+/// hard-coded key material or a fixed GCM nonce. Real item nonces use a
+/// monotonic counter in `1..=MAX_IV`; AES-GCM nonces are built as
+/// `[9 zero bytes][3-byte counter]`. CodeQL `hard-coded-cryptographic-value`
+/// on this constant is a false positive (CWE-321/CWE-1204 do not apply).
+pub const MAX_IV: u32 = (1 << 24) - 1;
 
-/// Reserved IV for policy encryption (must not be used for collection items)
+/// Reserved counter for policy encryption (must not be used for collection items).
+/// Spec-mandated sentinel, not an encryption key or secret.
 pub const RESERVED_POLICY_IV: u32 = 0;
 
 /// Default rotation threshold (conservative: 2^23 = 8,388,608)

--- a/examples/xtest_cli.rs
+++ b/examples/xtest_cli.rs
@@ -336,12 +336,13 @@ async fn encrypt_zip(
     // RSA-OAEP wrap payload key with KAS public key (go default ztdf)
     let wrapped_key = wrap_key_with_rsa_oaep(tdf_encryption.payload_key(), &public_key_pem)?;
 
-    // Build manifest — schemaVersion 4.3.0 matches go@main hexless default
+    // Build manifest — root schemaVersion 4.3.0 matches go@main hexless default.
+    // Do not set payload.tdf_spec_version: go/Swift omit it; otdf-python's strict
+    // ManifestPayload rejects the unknown field (rust→python Stage-2).
     let mut manifest = TdfManifest::new("0.payload".to_string(), kas_url.to_string());
     manifest.schema_version = Some("4.3.0".to_string());
     manifest.encryption_information.method.algorithm = "AES-256-GCM".to_string();
     manifest.encryption_information.method.iv = String::new();
-    manifest.payload.tdf_spec_version = Some("4.3.0".to_string());
 
     // Set policy
     manifest.set_policy(policy)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -212,6 +212,59 @@ mod tests {
     }
 
     #[test]
+    fn test_payload_omits_tdf_spec_version_by_default() {
+        // go platform Payload has no tdf_spec_version field; Python ManifestPayload
+        // is a strict dataclass without it. Emitting the field breaks rust→python.
+        let manifest = TdfManifest::new(
+            "0.payload".to_string(),
+            "http://kas.example.com:4000".to_string(),
+        );
+        assert!(manifest.payload.tdf_spec_version.is_none());
+
+        let value = serde_json::to_value(&manifest).unwrap();
+        let payload = value.get("payload").expect("payload object");
+        assert!(
+            payload.get("tdf_spec_version").is_none(),
+            "default encrypt path must not serialize payload.tdf_spec_version: {payload}"
+        );
+        // Root schemaVersion remains the peer-visible version signal.
+        assert_eq!(
+            value.get("schemaVersion").and_then(|v| v.as_str()),
+            Some("3.0.0")
+        );
+
+        // Still accept the field when reading peer manifests that include it.
+        let with_spec = r#"{
+            "payload": {
+                "type": "reference",
+                "url": "0.payload",
+                "protocol": "zip",
+                "isEncrypted": true,
+                "tdf_spec_version": "4.3.0"
+            },
+            "encryptionInformation": {
+                "type": "split",
+                "keyAccess": [],
+                "method": {"algorithm": "AES-256-GCM", "isStreamable": true, "iv": ""},
+                "integrityInformation": {
+                    "rootSignature": {"alg": "HS256", "sig": ""},
+                    "segmentHashAlg": "GMAC",
+                    "segments": [],
+                    "segmentSizeDefault": 0,
+                    "encryptedSegmentSizeDefault": 0
+                },
+                "policy": ""
+            },
+            "schemaVersion": "4.3.0"
+        }"#;
+        let read: TdfManifest = serde_json::from_str(with_spec).unwrap();
+        assert_eq!(
+            read.payload.tdf_spec_version.as_deref(),
+            Some("4.3.0")
+        );
+    }
+
+    #[test]
     fn test_policy_raw_encoding() {
         let mut manifest = TdfManifest::new(
             "0.payload".to_string(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -258,10 +258,7 @@ mod tests {
             "schemaVersion": "4.3.0"
         }"#;
         let read: TdfManifest = serde_json::from_str(with_spec).unwrap();
-        assert_eq!(
-            read.payload.tdf_spec_version.as_deref(),
-            Some("4.3.0")
-        );
+        assert_eq!(read.payload.tdf_spec_version.as_deref(), Some("4.3.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Interop fix:** Stop emitting `payload.tdf_spec_version` on encrypt (`Payload::default`, `TdfManifest::new`, `xtest_cli`). Go and Swift only set root `schemaVersion`; otdf-python’s strict `ManifestPayload` rejects the unknown field and failed **rust → python** Stage-2 in community-xtest (`TypeError: unexpected keyword argument 'tdf_spec_version'`). Field is still accepted on read.
- **CI:** Add `X-Test` workflow (same pattern as OpenTDFKit): resolve floating pins, wire this PR checkout into `opentdf-tests` `sdk/rust`, run Stage-1 **rust × go** Base TDF on ubuntu.

## Context

Seen on [arkavo-org/opentdf-tests#4](https://github.com/arkavo-org/opentdf-tests/pull/4) stage2 jobs. Stage-1 rust ↔ go stayed green; only rust-encrypted TDFs broke python decrypt.

## Test plan

- [x] `cargo test --lib test_payload_omits_tdf_spec_version`
- [ ] CI **X-Test / rust ↔ go** on this PR
- [ ] After merge + pin/release, re-run community stage2 rust→python cell