### PR TITLE
chore(release): 0.14.1 omit payload.tdf_spec_version + X-Test CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-07-13
+
 ### Fixed
 
-- Stop emitting `payload.tdf_spec_version` on encrypt (default + `xtest_cli`). Go and Swift only set root `schemaVersion`; otdf-python’s strict `ManifestPayload` rejects the unknown field and broke rust→python Stage-2. Field is still accepted on read.
+- Stop emitting `payload.tdf_spec_version` on encrypt (default + `xtest_cli`). Go and Swift only set root `schemaVersion`; otdf-python’s strict `ManifestPayload` rejects the unknown field and broke rust→python Stage-2 ([#89](https://github.com/arkavo-org/opentdf-rs/pull/89)). Field is still accepted on read.
 
 ### Added
 
-- **X-Test** GitHub Actions workflow (`.github/workflows/xtest.yml`): rust ↔ go Stage-1 via `arkavo-org/opentdf-tests`, wiring the PR checkout into `xtest/sdk/rust` (same pattern as OpenTDFKit).
+- **X-Test** GitHub Actions workflow (`.github/workflows/xtest.yml`): rust ↔ go Stage-1 via `arkavo-org/opentdf-tests`, wiring the PR checkout into `xtest/sdk/rust` (same pattern as OpenTDFKit) ([#89](https://github.com/arkavo-org/opentdf-rs/pull/89)).
 
 ## [0.14.0] — 2026-07-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 
 [dependencies]
 # New modular crates
-opentdf-protocol = { path = "crates/protocol", version = "0.14.0" }
-opentdf-crypto = { path = "crates/crypto", version = "0.14.0", default-features = false }
+opentdf-protocol = { path = "crates/protocol", version = "0.14.1" }
+opentdf-crypto = { path = "crates/crypto", version = "0.14.1", default-features = false }
 
 # Core dependencies (using workspace versions)
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
@@ -68,7 +68,7 @@ ciborium = "0.2"
 members = ["crates/protocol", "crates/crypto", "crates/kas", "crates/wasm"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 
 [workspace.dependencies]
 # Core serialization

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -36,7 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 # Protocol types (for NanoTDF)
-opentdf-protocol = { path = "../protocol", version = "0.14.0" }
+opentdf-protocol = { path = "../protocol", version = "0.14.1" }
 
 # KAS feature dependencies (EC, HKDF)
 p256 = { workspace = true, optional = true }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -26,8 +26,8 @@ wasm-opt = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-opentdf = { path = "../..", version = "0.14.0", default-features = false }
-opentdf-protocol = { path = "../protocol", version = "0.14.0" }
+opentdf = { path = "../..", version = "0.14.1", default-features = false }
+opentdf-protocol = { path = "../protocol", version = "0.14.1" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde.workspace = true


### PR DESCRIPTION
## Summary

Cut **0.14.1** so floating `latest` (community-xtest / opentdf-tests) includes the fix from [#89](https://github.com/arkavo-org/opentdf-rs/pull/89).

### Included since 0.14.0

- Omit `payload.tdf_spec_version` on encrypt (go/Swift parity; fixes otdf-python strict `ManifestPayload` on rust→python Stage-2)
- In-repo **X-Test** workflow: rust ↔ go Stage-1 via arkavo-org/opentdf-tests

### Release mechanics

Push to `main` with `Cargo.toml` paths triggers [Release](.github/workflows/release.yaml):
1. Build/test WASM
2. Tag `0.14.1` from workspace version
3. GitHub Release + npm package if configured

### Follow-up

- Re-run [opentdf-tests#4](https://github.com/arkavo-org/opentdf-tests/pull/4) community stage2 (should resolve rust `latest` → `0.14.1`)

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Release workflow creates tag `0.14.1` and marks it Latest
- [ ] `gh api repos/arkavo-org/opentdf-rs/releases/latest --jq .tag_name` → `0.14.1`