### PR TITLE
ci: restrictive permissions on feature.yaml workflow

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Preserving local work that existed only on this machine (commits dated 2026-05-24). Opened as a **draft** for triage — not proposed for merge as-is.

**1 commit(s)** ahead of `main`:

- \`839b10b\` ci: add restrictive permissions to feature.yaml workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXZEShmKDicGgfd81J2JaS